### PR TITLE
Ignore config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,3 @@
 .settings/
 target/
 ~/
-src/database.properties
-build.properties

--- a/src/database.properties
+++ b/src/database.properties
@@ -1,0 +1,9 @@
+# database properties
+database.driver=com.mysql.jdbc.Driver
+database.url=jdbc:mysql://localhost:3306/v2v_new
+database.user=root
+database.password=root
+database.acquireIncrement=1
+database.minPoolSize=5
+database.maxPoolSize=10
+database.maxIdleTime=600


### PR DESCRIPTION
Remove config files from .gitignore.

Ignore config files using 'update-index --assume-unchanged':

git update-index --assume-unchanged build.properties
git update-index --assume-unchanged src/database.properties

(See
https://help.github.com/articles/ignoring-files#ignoring-versioned-files
)
