### PR TITLE
Add tomcat7-maven-plugin to pom.xml (See #141)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,13 @@
 		</resources>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.tomcat.maven</groupId>
+        		<artifactId>tomcat7-maven-plugin</artifactId>
+				<configuration>
+					<server>tomcat</server>
+				</configuration>
+			</plugin>
+			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.0</version>
 				<configuration>


### PR DESCRIPTION
Add tomcat7-maven-plugin to pom.xml (See #141)

This is the setup to assist with deploying BSIS to a local Tomcat server. This is not suggested for production instances.

tomcat7-maven-plugin added to pom.xml:

![image](https://f.cloud.github.com/assets/1052668/2130942/7605d6c4-9299-11e3-802d-7904eab6427b.png)

Used instructions from http://tomcat.apache.org/maven-plugin-2.0/tomcat7-maven-plugin/usage.html
and http://www.mkyong.com/maven/how-to-deploy-maven-based-war-file-to-tomcat/ (uses a different plugin, but demonstrates setup of tomcat-users.xml and maven settings.xml)
- Add tomcat user to %TOMCAT_PATH%/conf/tomcat-users.xml:
  <tomcat-users>
  <role rolename="manager-gui"/>
  <user username="tomcat" password="tomcat" roles="manager-gui"/>
  </tomcat-users>
- Add Tomcat server and authentication details to Maven %MAVEN_PATH%/conf/settings.xml:
  <settings>
  //...
  <servers>
  <server>
    <id>tomcat</id>
    <username>tomcat</username>
    <password>tomcat</password>
  </server>
  <servers>
  //...
  </settings>
- The username and password in settings.xml should match those used in tomcat-users.xml
- The <server> <id> used in settings.xml should match the server name used for <server> in pom.xml.

To make use of the plugin, the following can be used:
- mvn tomcat7:deploy
- mvn tomcat7:redeploy
- or use along with 'clean install':
  - mvn clean install tomcat7:deploy
