### PR TITLE
Validate current password when updating users

### DIFF
--- a/src/backingform/validator/UserBackingFormValidator.java
+++ b/src/backingform/validator/UserBackingFormValidator.java
@@ -12,85 +12,86 @@ import repository.UserRepository;
 import viewmodel.UserViewModel;
 import backingform.UserBackingForm;
 import controller.UtilController;
+
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 public class UserBackingFormValidator implements Validator {
 
-  private Validator validator;
-	private UtilController utilController;
-	private UserRepository userRepository;
+    private Validator validator;
+    private UtilController utilController;
+    private UserRepository userRepository;
 
-  public UserBackingFormValidator(Validator validator, UtilController utilController, UserRepository userRepository) {
-    super();
-    this.validator = validator;
-    this.utilController = utilController;
-    this.userRepository=userRepository;
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  public boolean supports(Class<?> clazz) {
-    return Arrays.asList(UserBackingForm.class, User.class, UserViewModel.class).contains(clazz);
-  }
-
-  @Override
-  public void validate(Object obj, Errors errors) {
-    if (obj == null || validator == null)
-      return;
-    ValidationUtils.invokeValidator(validator, obj, errors);
-    UserBackingForm form = (UserBackingForm) obj;
-     utilController.commonFieldChecks(form, "user", errors);
-    checkUserName(form,errors);
-    if(form.getId() != null){
-       if(form.isModifyPassword()){
-           comparePassword(form, errors);
-       }
-    }
-    else  
-    	  comparePassword(form,errors);
-     
-     checkRoles(form,errors);
-  }
-  
- 
-  private void comparePassword(UserBackingForm form, Errors errors) {
-	if( StringUtils.isBlank(form.getPassword()) ||  StringUtils.isBlank(form.getConfirmPassword()))
-  	    errors.rejectValue("user.password","user.incorrect" ,"Password cannot be blank");
-  	    else
-  	if(!form.getPassword().equals(form.getConfirmPassword())){
-  		errors.rejectValue("user.password","user.incorrect" ,"Passwords do not match");
-  	}
-  
-  }
-  
-  private void checkRoles(UserBackingForm form, Errors errors) {
-	  if(form.getRoles().isEmpty())
-		  errors.rejectValue("user.roles","user.selectRole" ,"Must select at least one Role");
-	  return;
-  }
-  
-  private void checkUserName(UserBackingForm form, Errors errors) {
-      
-  	boolean flag=false;
-  	String userName=form.getUser().getUsername();
-  	User existingUser=null;
-        
-  	if (utilController.isDuplicateUserName(form.getUser())){
-    	errors.rejectValue("user.username", "userName.nonunique", "Username already exists.");
+    public UserBackingFormValidator(Validator validator, UtilController utilController, UserRepository userRepository) {
+        super();
+        this.validator = validator;
+        this.utilController = utilController;
+        this.userRepository = userRepository;
     }
 
-  	if(userName.length() <= 2 ||  userName.length() >= 50){
-  		flag=true;
-  	}
-  	
-  	if(!userName.matches("^[a-zA-Z0-9_.-]*$")){
-  		flag=true;
-  	}
-  	
-  	if(flag && userName.length() > 0){
-  		errors.rejectValue("user.username","user.incorrect" ,"Username invalid. Use only alphanumeric characters, underscore (_), hyphen (-), and period (.).");
-  	}
-  
-  }
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return Arrays.asList(UserBackingForm.class, User.class, UserViewModel.class).contains(clazz);
+    }
+
+    @Override
+    public void validate(Object obj, Errors errors) {
+        if (obj == null || validator == null) {
+            return;
+        }
+        ValidationUtils.invokeValidator(validator, obj, errors);
+        UserBackingForm form = (UserBackingForm) obj;
+        utilController.commonFieldChecks(form, "user", errors);
+        checkUserName(form, errors);
+        if (form.getId() != null) {
+            if (form.isModifyPassword()) {
+                comparePassword(form, errors);
+            }
+        } else {
+            comparePassword(form, errors);
+        }
+
+        checkRoles(form, errors);
+    }
+
+    private void comparePassword(UserBackingForm form, Errors errors) {
+        if (StringUtils.isBlank(form.getPassword()) || StringUtils.isBlank(form.getConfirmPassword())) {
+            errors.rejectValue("user.password", "user.incorrect", "Password cannot be blank");
+        } else if (!form.getPassword().equals(form.getConfirmPassword())) {
+            errors.rejectValue("user.password", "user.incorrect", "Passwords do not match");
+        }
+
+    }
+
+    private void checkRoles(UserBackingForm form, Errors errors) {
+        if (form.getRoles().isEmpty()) {
+            errors.rejectValue("user.roles", "user.selectRole", "Must select at least one Role");
+        }
+    }
+
+    private void checkUserName(UserBackingForm form, Errors errors) {
+
+        boolean flag = false;
+        String userName = form.getUser().getUsername();
+        User existingUser = null;
+
+        if (utilController.isDuplicateUserName(form.getUser())) {
+            errors.rejectValue("user.username", "userName.nonunique", "Username already exists.");
+        }
+
+        if (userName.length() <= 2 || userName.length() >= 50) {
+            flag = true;
+        }
+
+        if (!userName.matches("^[a-zA-Z0-9_.-]*$")) {
+            flag = true;
+        }
+
+        if (flag && userName.length() > 0) {
+            errors.rejectValue("user.username", "user.incorrect",
+                    "Username invalid. Use only alphanumeric characters, underscore (_), hyphen (-), and period (.).");
+        }
+
+    }
 }


### PR DESCRIPTION
Related to https://github.com/jembi/bsis/issues/284 and adds back the current password validation that was removed in https://github.com/jembi/bsis/pull/291.

The validation will be skipped if the logged on user has the permission to "Manage Users" and has not provided a current password (i.e. when they are not updating their own password).