### PR TITLE
Automated deferrals 345

### DIFF
--- a/liquibase/db-changelog.xml
+++ b/liquibase/db-changelog.xml
@@ -1614,15 +1614,11 @@
 	   <comment>Add default duration days to deferral reasons.</comment>
 	
 	   <addColumn tableName="DeferralReason">
-	       <column name="defaultDuration" type="SMALLINT UNSIGNED" defaultValue="0">
-	           <constraints nullable="false" />
-	       </column>
+	       <column name="defaultDuration" type="SMALLINT UNSIGNED" defaultValue="NULL" />
 	   </addColumn>
 
 	   <addColumn tableName="DeferralReason_AUD">
-	       <column name="defaultDuration" type="SMALLINT UNSIGNED" defaultValue="0">
-	           <constraints nullable="false" />
-	       </column>
+	       <column name="defaultDuration" type="SMALLINT UNSIGNED" defaultValue="NULL" />
 	   </addColumn>
 	</changeSet>
 	
@@ -1663,7 +1659,6 @@
 	   <insert tableName="DeferralReason">
 	       <column name="reason">TTI unsafe</column>
 	       <column name="type">AUTOMATED_TTI_UNSAFE</column>
-	       <column name="defaultDuration">65535</column>
 	       <column name="durationType">PERMANENT</column>
 	       <column name="isDeleted">0</column>
 	   </insert>

--- a/liquibase/db-changelog.xml
+++ b/liquibase/db-changelog.xml
@@ -1625,5 +1625,49 @@
 	       </column>
 	   </addColumn>
 	</changeSet>
+	
+	<changeSet id="20150903-1641" author="bausmeier">
+	   
+	   <addColumn tableName="DonorDeferral">
+	       <column name="deferralType" type="VARCHAR(30)">
+	           <constraints nullable="false" />
+	       </column>
+	   </addColumn>
+	   
+	   <addColumn tableName="DonorDeferral_AUD">
+	       <column name="deferralType" type="VARCHAR(30)">
+	           <constraints nullable="false" />
+	       </column>
+	   </addColumn>
+
+	   <update tableName="DonorDeferral">
+	       <column name="deferralType" value="TEMPORARY" />
+	   </update>
+
+
+	   <addColumn tableName="DeferralReason">
+	       <column name="type" type="VARCHAR(30)">
+	           <constraints nullable="false" />
+	       </column>
+	   </addColumn>
+
+	   <addColumn tableName="DeferralReason_AUD">
+	       <column name="type" type="VARCHAR(30)">
+	           <constraints nullable="false" />
+	       </column>
+	   </addColumn>
+
+	   <update tableName="DeferralReason">
+	       <column name="type" value="NORMAL" />
+	   </update>
+	   
+	   <insert tableName="DeferralReason">
+	       <column name="reason">TTI unsafe</column>
+	       <column name="type">AUTOMATED_TTI_UNSAFE</column>
+	       <column name="defaultDuration">65535</column>
+	       <column name="isDeleted">0</column>
+	   </insert>
+	   
+	</changeSet>
 
 </databaseChangeLog>

--- a/liquibase/db-changelog.xml
+++ b/liquibase/db-changelog.xml
@@ -1609,5 +1609,21 @@
 			<column name="REVTYPE" type="tinyint(4)"></column>
 		</createTable>
 	</changeSet>
+	
+	<changeSet id="20150903-1118" author="bausmeier">
+	   <comment>Add default duration days to deferral reasons.</comment>
+	
+	   <addColumn tableName="DeferralReason">
+	       <column name="defaultDuration" type="SMALLINT UNSIGNED" defaultValue="0">
+	           <constraints nullable="false" />
+	       </column>
+	   </addColumn>
+
+	   <addColumn tableName="DeferralReason_AUD">
+	       <column name="defaultDuration" type="SMALLINT UNSIGNED" defaultValue="0">
+	           <constraints nullable="false" />
+	       </column>
+	   </addColumn>
+	</changeSet>
 
 </databaseChangeLog>

--- a/liquibase/db-changelog.xml
+++ b/liquibase/db-changelog.xml
@@ -1623,6 +1623,7 @@
 	</changeSet>
 	
 	<changeSet id="20150907-0917" author="bausmeier">
+		<comment>Add deferral reason durationType column.</comment>
 	   
 	   <addColumn tableName="DeferralReason">
 	       <column name="durationType" type="VARCHAR(30)">
@@ -1636,32 +1637,36 @@
 	       </column>
 	   </addColumn>
 
-	   <update tableName="DeferralReason">
-	       <column name="durationType" value="TEMPORARY" />
-	   </update>
-
-	   <addColumn tableName="DeferralReason">
-	       <column name="type" type="VARCHAR(30)">
-	           <constraints nullable="false" />
-	       </column>
-	   </addColumn>
-
-	   <addColumn tableName="DeferralReason_AUD">
-	       <column name="type" type="VARCHAR(30)">
-	           <constraints nullable="false" />
-	       </column>
-	   </addColumn>
-
-	   <update tableName="DeferralReason">
-	       <column name="type" value="NORMAL" />
-	   </update>
-	   
-	   <insert tableName="DeferralReason">
-	       <column name="reason">TTI unsafe</column>
-	       <column name="type">AUTOMATED_TTI_UNSAFE</column>
-	       <column name="durationType">PERMANENT</column>
-	       <column name="isDeleted">0</column>
-	   </insert>
+		<update tableName="DeferralReason">
+       		<column name="durationType" value="TEMPORARY" />
+   		</update>
+	</changeSet>
+	
+	<changeSet id="20150907-0918" author="bausmeier">
+		<comment>Add Deferral Reason type column and TTI unsafe deferral reason.</comment>
+		
+			<addColumn tableName="DeferralReason">
+		       <column name="type" type="VARCHAR(30)">
+		           <constraints nullable="false" />
+		       </column>
+		   </addColumn>
+	
+		   <addColumn tableName="DeferralReason_AUD">
+		       <column name="type" type="VARCHAR(30)">
+		           <constraints nullable="false" />
+		       </column>
+		   </addColumn>
+	
+		   <update tableName="DeferralReason">
+		       <column name="type" value="NORMAL" />
+		   </update>
+	
+		   <insert tableName="DeferralReason">
+		       <column name="reason">TTI Unsafe</column>
+		       <column name="type">AUTOMATED_TTI_UNSAFE</column>
+		       <column name="durationType">PERMANENT</column>
+		       <column name="isDeleted">0</column>
+		   </insert>
 	   
 	</changeSet>
 

--- a/liquibase/db-changelog.xml
+++ b/liquibase/db-changelog.xml
@@ -1626,24 +1626,23 @@
 	   </addColumn>
 	</changeSet>
 	
-	<changeSet id="20150903-1641" author="bausmeier">
+	<changeSet id="20150907-0917" author="bausmeier">
 	   
-	   <addColumn tableName="DonorDeferral">
-	       <column name="deferralType" type="VARCHAR(30)">
+	   <addColumn tableName="DeferralReason">
+	       <column name="durationType" type="VARCHAR(30)">
 	           <constraints nullable="false" />
 	       </column>
 	   </addColumn>
 	   
-	   <addColumn tableName="DonorDeferral_AUD">
-	       <column name="deferralType" type="VARCHAR(30)">
+	   <addColumn tableName="DeferralReason_AUD">
+	       <column name="durationType" type="VARCHAR(30)">
 	           <constraints nullable="false" />
 	       </column>
 	   </addColumn>
 
-	   <update tableName="DonorDeferral">
-	       <column name="deferralType" value="TEMPORARY" />
+	   <update tableName="DeferralReason">
+	       <column name="durationType" value="TEMPORARY" />
 	   </update>
-
 
 	   <addColumn tableName="DeferralReason">
 	       <column name="type" type="VARCHAR(30)">
@@ -1665,6 +1664,7 @@
 	       <column name="reason">TTI unsafe</column>
 	       <column name="type">AUTOMATED_TTI_UNSAFE</column>
 	       <column name="defaultDuration">65535</column>
+	       <column name="durationType">PERMANENT</column>
 	       <column name="isDeleted">0</column>
 	   </insert>
 	   

--- a/liquibase/db-data-lbts.xml
+++ b/liquibase/db-data-lbts.xml
@@ -626,31 +626,37 @@
 			<column name="reason" value="High risk behaviour"/>
 			<column name="isDeleted" value="0"/>
 			<column name="type" value="NORMAL" />
+			<column name="durationType" value="TEMPORARY" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Low weight"/>
 			<column name="isDeleted" value="0"/>
 			<column name="type" value="NORMAL" />
+			<column name="durationType" value="TEMPORARY" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Low haemoglobin"/>
 			<column name="isDeleted" value="0"/>
 			<column name="type" value="NORMAL" />
+			<column name="durationType" value="TEMPORARY" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Other reasons"/>
 			<column name="isDeleted" value="0"/>
 			<column name="type" value="NORMAL" />
+			<column name="durationType" value="TEMPORARY" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Other medical conditions"/>
 			<column name="isDeleted" value="0"/>
 			<column name="type" value="NORMAL" />
+			<column name="durationType" value="TEMPORARY" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Travel history"/>
 			<column name="isDeleted" value="0"/>
 			<column name="type" value="NORMAL" />
+			<column name="durationType" value="TEMPORARY" />
 		</insert>
 	</changeSet>
 	

--- a/liquibase/db-data-lbts.xml
+++ b/liquibase/db-data-lbts.xml
@@ -625,26 +625,32 @@
 		<insert tableName="DeferralReason">
 			<column name="reason" value="High risk behaviour"/>
 			<column name="isDeleted" value="0"/>
+			<column name="type" value="NORMAL" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Low weight"/>
 			<column name="isDeleted" value="0"/>
+			<column name="type" value="NORMAL" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Low haemoglobin"/>
 			<column name="isDeleted" value="0"/>
+			<column name="type" value="NORMAL" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Other reasons"/>
 			<column name="isDeleted" value="0"/>
+			<column name="type" value="NORMAL" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Other medical conditions"/>
 			<column name="isDeleted" value="0"/>
+			<column name="type" value="NORMAL" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Travel history"/>
 			<column name="isDeleted" value="0"/>
+			<column name="type" value="NORMAL" />
 		</insert>
 	</changeSet>
 	

--- a/liquibase/db-data.xml
+++ b/liquibase/db-data.xml
@@ -381,26 +381,32 @@
 		<insert tableName="DeferralReason">
 			<column name="reason" value="High risk behaviour"/>
 			<column name="isDeleted" value="0"/>
+			<column name="type" value="NORMAL" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Low weight"/>
 			<column name="isDeleted" value="0"/>
+			<column name="type" value="NORMAL" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Low haemoglobin"/>
 			<column name="isDeleted" value="0"/>
+			<column name="type" value="NORMAL" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Other reasons"/>
 			<column name="isDeleted" value="0"/>
+			<column name="type" value="NORMAL" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Other medical conditions"/>
 			<column name="isDeleted" value="0"/>
+			<column name="type" value="NORMAL" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Travel history"/>
 			<column name="isDeleted" value="0"/>
+			<column name="type" value="NORMAL" />
 		</insert>
 	</changeSet>
 	

--- a/liquibase/db-data.xml
+++ b/liquibase/db-data.xml
@@ -382,31 +382,37 @@
 			<column name="reason" value="High risk behaviour"/>
 			<column name="isDeleted" value="0"/>
 			<column name="type" value="NORMAL" />
+			<column name="durationType" value="TEMPORARY" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Low weight"/>
 			<column name="isDeleted" value="0"/>
 			<column name="type" value="NORMAL" />
+			<column name="durationType" value="TEMPORARY" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Low haemoglobin"/>
 			<column name="isDeleted" value="0"/>
 			<column name="type" value="NORMAL" />
+			<column name="durationType" value="TEMPORARY" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Other reasons"/>
 			<column name="isDeleted" value="0"/>
 			<column name="type" value="NORMAL" />
+			<column name="durationType" value="TEMPORARY" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Other medical conditions"/>
 			<column name="isDeleted" value="0"/>
 			<column name="type" value="NORMAL" />
+			<column name="durationType" value="TEMPORARY" />
 		</insert>
 		<insert tableName="DeferralReason">
 			<column name="reason" value="Travel history"/>
 			<column name="isDeleted" value="0"/>
 			<column name="type" value="NORMAL" />
+			<column name="durationType" value="TEMPORARY" />
 		</insert>
 	</changeSet>
 	

--- a/src/backingform/DeferralReasonBackingForm.java
+++ b/src/backingform/DeferralReasonBackingForm.java
@@ -46,11 +46,11 @@ public class DeferralReasonBackingForm {
         deferralReason.setIsDeleted(isDeleted);
     }
     
-    public int getDefaultDuration() {
+    public Integer getDefaultDuration() {
         return deferralReason.getDefaultDuration();
     }
     
-    public void setDefaultDuration(int defaultDuration) {
+    public void setDefaultDuration(Integer defaultDuration) {
         deferralReason.setDefaultDuration(defaultDuration);
     }
     

--- a/src/backingform/DeferralReasonBackingForm.java
+++ b/src/backingform/DeferralReasonBackingForm.java
@@ -44,5 +44,13 @@ public class DeferralReasonBackingForm {
     public void setIsDeleted(Boolean isDeleted){
         deferralReason.setIsDeleted(isDeleted);
     }
+    
+    public int getDefaultDuration() {
+        return deferralReason.getDefaultDuration();
+    }
+    
+    public void setDefaultDuration(int defaultDuration) {
+        deferralReason.setDefaultDuration(defaultDuration);
+    }
 
 }

--- a/src/backingform/DeferralReasonBackingForm.java
+++ b/src/backingform/DeferralReasonBackingForm.java
@@ -2,10 +2,11 @@
 package backingform;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import model.donordeferral.DeferralReason;
+import model.donordeferral.DurationType;
 
 import javax.validation.Valid;
-
 
 public class DeferralReasonBackingForm {
 
@@ -51,6 +52,17 @@ public class DeferralReasonBackingForm {
     
     public void setDefaultDuration(int defaultDuration) {
         deferralReason.setDefaultDuration(defaultDuration);
+    }
+    
+    public DurationType getDurationType() {
+        return deferralReason.getDurationType();
+    }
+    
+    public void setDurationType(DurationType durationType) {
+        if (durationType == null) {
+            return;
+        }
+        deferralReason.setDurationType(durationType);
     }
 
 }

--- a/src/backingform/validator/DeferralReasonBackingFormValidator.java
+++ b/src/backingform/validator/DeferralReasonBackingFormValidator.java
@@ -2,32 +2,24 @@ package backingform.validator;
 
 import java.util.Arrays;
 
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
+import model.donordeferral.DeferralReason;
+
 import org.springframework.validation.Errors;
-import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
 
-import model.donordeferral.DeferralReason;
-import repository.DeferralReasonRepository;
 import viewmodel.DeferralReasonViewModel;
 import backingform.DeferralReasonBackingForm;
 import controller.UtilController;
 
 public class DeferralReasonBackingFormValidator implements Validator {
 
-    private Validator validator;
     private UtilController utilController;
-    private DeferralReasonRepository deferralReasonRepository;
 
-    public DeferralReasonBackingFormValidator(Validator validator, UtilController utilController,DeferralReasonRepository deferralReasonRepository) {
+    public DeferralReasonBackingFormValidator(UtilController utilController) {
         super();
-        this.validator = validator;
         this.utilController = utilController;
-        this.deferralReasonRepository=deferralReasonRepository;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public boolean supports(Class<?> clazz) {
         return Arrays.asList(DeferralReasonBackingForm.class, DeferralReason.class, DeferralReasonViewModel.class).contains(clazz);
@@ -36,17 +28,18 @@ public class DeferralReasonBackingFormValidator implements Validator {
     @Override
     public void validate(Object obj, Errors errors) {
 
-        if (obj == null || validator == null)
+        if (obj == null) {
             return;
-
-        ValidationUtils.invokeValidator(validator, obj, errors);
-        DeferralReasonBackingForm form = (DeferralReasonBackingForm) obj;
-
-        if (utilController.isDuplicateDeferralReason(form.getDeferralReason())){
-            errors.rejectValue("reason", "400",
-                    "Deferral Reason already exists.");
         }
 
+        DeferralReasonBackingForm form = (DeferralReasonBackingForm) obj;
 
+        if (utilController.isDuplicateDeferralReason(form.getDeferralReason())) {
+            errors.rejectValue("reason", "400", "Deferral Reason already exists.");
+        }
+        
+        if (form.getDefaultDuration() <= 0) {
+            errors.rejectValue("defaultDuration", "400", "Default duration must be a positive number of days");
+        }
     }
 }

--- a/src/backingform/validator/DeferralReasonBackingFormValidator.java
+++ b/src/backingform/validator/DeferralReasonBackingFormValidator.java
@@ -3,6 +3,7 @@ package backingform.validator;
 import java.util.Arrays;
 
 import model.donordeferral.DeferralReason;
+import model.donordeferral.DurationType;
 
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
@@ -38,7 +39,8 @@ public class DeferralReasonBackingFormValidator implements Validator {
             errors.rejectValue("reason", "400", "Deferral Reason already exists.");
         }
         
-        if (form.getDefaultDuration() <= 0) {
+        if (form.getDurationType() != DurationType.PERMANENT && (form.getDefaultDuration() == null ||
+                form.getDefaultDuration() <= 0)) {
             errors.rejectValue("defaultDuration", "400", "Default duration must be a positive number of days");
         }
     }

--- a/src/controller/DeferralReasonController.java
+++ b/src/controller/DeferralReasonController.java
@@ -37,7 +37,7 @@ public class DeferralReasonController {
 
     @InitBinder
     protected void initBinder(WebDataBinder binder) {
-        binder.setValidator(new DeferralReasonBackingFormValidator(binder.getValidator(), utilController, deferralReasonRepository));
+        binder.setValidator(new DeferralReasonBackingFormValidator(utilController));
     }
 
     @RequestMapping(method=RequestMethod.GET)

--- a/src/model/component/Component.java
+++ b/src/model/component/Component.java
@@ -13,6 +13,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Temporal;
@@ -34,13 +36,18 @@ import org.hibernate.envers.Audited;
 import org.hibernate.envers.NotAudited;
 import org.hibernate.envers.RelationTargetAuditMode;
 
+import repository.ComponentNamedQueryConstants;
+
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 
 import constraintvalidator.ComponentTypeExists;
 import constraintvalidator.DonationExists;
 
-
+@NamedQueries({
+    @NamedQuery(name = ComponentNamedQueryConstants.NAME_UPDATE_COMPONENT_STATUS_FOR_DONOR,
+            query = ComponentNamedQueryConstants.QUERY_UPDATE_COMPONENT_STATUS_FOR_DONOR)
+})
 @Entity
 @Audited
 @JsonIdentityInfo(generator=ObjectIdGenerators.IntSequenceGenerator.class, property="@id")

--- a/src/model/donordeferral/DeferralReason.java
+++ b/src/model/donordeferral/DeferralReason.java
@@ -2,12 +2,22 @@ package model.donordeferral;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
 
 import org.hibernate.envers.Audited;
 
+import repository.DeferralReasonNamedQueryConstants;
+
+@NamedQueries({
+    @NamedQuery(name = DeferralReasonNamedQueryConstants.NAME_FIND_DEFERRAL_REASON_BY_TYPE,
+            query = DeferralReasonNamedQueryConstants.QUERY_FIND_DEFERRAL_REASON_BY_TYPE)
+})
 @Entity
 @Audited
 public class DeferralReason {
@@ -24,6 +34,10 @@ public class DeferralReason {
   
   @Column(nullable = false)
   private int defaultDuration; // in days
+  
+  @Column(length = 30, nullable = false)
+  @Enumerated(EnumType.STRING)
+  private DeferralReasonType type = DeferralReasonType.NORMAL;
   
   public Integer getId() {
     return id;
@@ -62,6 +76,14 @@ public class DeferralReason {
 
     public void setDefaultDuration(int defaultDuration) {
         this.defaultDuration = defaultDuration;
+    }
+
+    public DeferralReasonType getType() {
+        return type;
+    }
+
+    public void setType(DeferralReasonType type) {
+        this.type = type;
     }
 
 }

--- a/src/model/donordeferral/DeferralReason.java
+++ b/src/model/donordeferral/DeferralReason.java
@@ -39,6 +39,10 @@ public class DeferralReason {
   @Enumerated(EnumType.STRING)
   private DeferralReasonType type = DeferralReasonType.NORMAL;
   
+  @Column(length = 30, nullable = false)
+  @Enumerated(EnumType.STRING)
+  private DurationType durationType = DurationType.TEMPORARY;
+  
   public Integer getId() {
     return id;
   }
@@ -68,6 +72,7 @@ public class DeferralReason {
     this.reason = deferralReason.getReason();
     this.isDeleted = deferralReason.getIsDeleted();
     this.defaultDuration = deferralReason.getDefaultDuration();
+    this.durationType = deferralReason.getDurationType();
   }
 
     public int getDefaultDuration() {
@@ -84,6 +89,14 @@ public class DeferralReason {
 
     public void setType(DeferralReasonType type) {
         this.type = type;
+    }
+
+    public DurationType getDurationType() {
+        return durationType;
+    }
+
+    public void setDurationType(DurationType durationType) {
+        this.durationType = durationType;
     }
 
 }

--- a/src/model/donordeferral/DeferralReason.java
+++ b/src/model/donordeferral/DeferralReason.java
@@ -22,6 +22,9 @@ public class DeferralReason {
 
   private Boolean isDeleted;
   
+  @Column(nullable = false)
+  private int defaultDuration; // in days
+  
   public Integer getId() {
     return id;
   }
@@ -50,6 +53,15 @@ public class DeferralReason {
     this.id = deferralReason.getId();
     this.reason = deferralReason.getReason();
     this.isDeleted = deferralReason.getIsDeleted();
+    this.defaultDuration = deferralReason.getDefaultDuration();
   }
+
+    public int getDefaultDuration() {
+        return defaultDuration;
+    }
+
+    public void setDefaultDuration(int defaultDuration) {
+        this.defaultDuration = defaultDuration;
+    }
 
 }

--- a/src/model/donordeferral/DeferralReason.java
+++ b/src/model/donordeferral/DeferralReason.java
@@ -32,8 +32,8 @@ public class DeferralReason {
 
   private Boolean isDeleted;
   
-  @Column(nullable = false)
-  private int defaultDuration; // in days
+  @Column(nullable = true)
+  private Integer defaultDuration; // in days
   
   @Column(length = 30, nullable = false)
   @Enumerated(EnumType.STRING)
@@ -75,11 +75,11 @@ public class DeferralReason {
     this.durationType = deferralReason.getDurationType();
   }
 
-    public int getDefaultDuration() {
+    public Integer getDefaultDuration() {
         return defaultDuration;
     }
 
-    public void setDefaultDuration(int defaultDuration) {
+    public void setDefaultDuration(Integer defaultDuration) {
         this.defaultDuration = defaultDuration;
     }
 

--- a/src/model/donordeferral/DeferralReasonType.java
+++ b/src/model/donordeferral/DeferralReasonType.java
@@ -1,0 +1,14 @@
+package model.donordeferral;
+
+/** 
+ * The type of deferral reason. This is used to distinguish the deferral reason to be used for automated deferrals.
+ * 
+ * Exactly one non-deleted deferral reason should exist for each type other than NORMAL so that it can be looked up by
+ * this field.
+ */
+public enum DeferralReasonType {
+    
+    NORMAL,
+    AUTOMATED_TTI_UNSAFE;
+
+}

--- a/src/model/donordeferral/DeferralType.java
+++ b/src/model/donordeferral/DeferralType.java
@@ -1,0 +1,8 @@
+package model.donordeferral;
+
+public enum DeferralType {
+    
+    TEMPORARY,
+    PERMANENT;
+
+}

--- a/src/model/donordeferral/DonorDeferral.java
+++ b/src/model/donordeferral/DonorDeferral.java
@@ -13,8 +13,6 @@ import javax.persistence.GenerationType;
 import model.modificationtracker.ModificationTracker;
 import model.modificationtracker.RowModificationTracker;
 
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
@@ -61,10 +59,6 @@ public class DonorDeferral implements ModificationTracker{
   
   @Temporal(TemporalType.DATE)
   private Date voidedDate;
-  
-  @Column(length = 30, nullable = false)
-  @Enumerated(EnumType.STRING)
-  private DeferralType deferralType = DeferralType.TEMPORARY;
   
   @Valid
   private RowModificationTracker modificationTracker;
@@ -186,14 +180,6 @@ public class DonorDeferral implements ModificationTracker{
 	public void setVoidedDate(Date voidedDate) {
 		this.voidedDate = voidedDate;
 	}
-	
-	public DeferralType getDeferralType() {
-        return deferralType;
-    }
-
-    public void setDeferralType(DeferralType deferralType) {
-        this.deferralType = deferralType;
-    }
 
     public void copy(DonorDeferral deferral) {
 	    assert (deferral.getId().equals(this.getId()));

--- a/src/model/donordeferral/DonorDeferral.java
+++ b/src/model/donordeferral/DonorDeferral.java
@@ -4,12 +4,17 @@ import java.util.Date;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
+
 import model.modificationtracker.ModificationTracker;
 import model.modificationtracker.RowModificationTracker;
+
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
@@ -56,6 +61,10 @@ public class DonorDeferral implements ModificationTracker{
   
   @Temporal(TemporalType.DATE)
   private Date voidedDate;
+  
+  @Column(length = 30, nullable = false)
+  @Enumerated(EnumType.STRING)
+  private DeferralType deferralType = DeferralType.TEMPORARY;
   
   @Valid
   private RowModificationTracker modificationTracker;
@@ -178,7 +187,15 @@ public class DonorDeferral implements ModificationTracker{
 		this.voidedDate = voidedDate;
 	}
 	
-	public void copy(DonorDeferral deferral) {
+	public DeferralType getDeferralType() {
+        return deferralType;
+    }
+
+    public void setDeferralType(DeferralType deferralType) {
+        this.deferralType = deferralType;
+    }
+
+    public void copy(DonorDeferral deferral) {
 	    assert (deferral.getId().equals(this.getId()));
 	    setDeferredDonor(deferral.getDeferredDonor());
 	    setDeferredUntil(deferral.getDeferredUntil());

--- a/src/model/donordeferral/DurationType.java
+++ b/src/model/donordeferral/DurationType.java
@@ -1,6 +1,6 @@
 package model.donordeferral;
 
-public enum DeferralType {
+public enum DurationType {
     
     TEMPORARY,
     PERMANENT;

--- a/src/repository/ComponentNamedQueryConstants.java
+++ b/src/repository/ComponentNamedQueryConstants.java
@@ -1,0 +1,17 @@
+package repository;
+
+public class ComponentNamedQueryConstants {
+    
+    public static final String NAME_UPDATE_COMPONENT_STATUS_FOR_DONOR =
+            "Component.updateComponentStatusForDonor";
+    public static final String QUERY_UPDATE_COMPONENT_STATUS_FOR_DONOR =
+            "UPDATE Component c " +
+            "SET c.status = :newStatus " +
+            "WHERE c.status = :oldStatus " +
+            "AND c.donation IN (" +
+            "  SELECT d " +
+            "  FROM Donation d " +
+            "  WHERE d.donor = :donor " +
+            ") ";
+
+}

--- a/src/repository/ComponentRepository.java
+++ b/src/repository/ComponentRepository.java
@@ -33,6 +33,7 @@ import model.componentmovement.ComponentStatusChangeType;
 import model.componenttype.ComponentType;
 import model.componenttype.ComponentTypeCombination;
 import model.donation.Donation;
+import model.donor.Donor;
 import model.request.Request;
 import model.util.BloodGroup;
 
@@ -41,6 +42,7 @@ import org.joda.time.DateTime;
 import org.joda.time.Days;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
@@ -955,4 +957,15 @@ public class ComponentRepository {
      	component.setStatus(ComponentStatus.PROCESSED);
      	em.merge(component);
   }
+  
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void updateComponentStatusForDonor(ComponentStatus oldStatus, ComponentStatus newStatus,
+            Donor donor) {
+
+        em.createNamedQuery(ComponentNamedQueryConstants.NAME_UPDATE_COMPONENT_STATUS_FOR_DONOR)
+            .setParameter("oldStatus", oldStatus)
+            .setParameter("newStatus", newStatus)
+            .setParameter("donor", donor)
+            .executeUpdate();
+    }
 }

--- a/src/repository/DeferralReasonNamedQueryConstants.java
+++ b/src/repository/DeferralReasonNamedQueryConstants.java
@@ -1,0 +1,13 @@
+package repository;
+
+public class DeferralReasonNamedQueryConstants {
+    
+    public static final String NAME_FIND_DEFERRAL_REASON_BY_TYPE =
+            "DeferralReason.findDeferralReasonByType";
+    public static final String QUERY_FIND_DEFERRAL_REASON_BY_TYPE =
+            "SELECT dr " +
+            "FROM DeferralReason dr " +
+            "WHERE dr.type = :type " +
+            "AND dr.isDeleted = :deleted ";
+
+}

--- a/src/repository/DeferralReasonRepository.java
+++ b/src/repository/DeferralReasonRepository.java
@@ -1,13 +1,17 @@
 package repository;
 
 import model.donordeferral.DeferralReason;
+import model.donordeferral.DeferralReasonType;
+
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
+import javax.persistence.NonUniqueResultException;
 import javax.persistence.PersistenceContext;
 import javax.persistence.TypedQuery;
+
 import java.util.List;
 
 @Repository
@@ -77,5 +81,16 @@ public class DeferralReasonRepository {
         em.merge(existingDeferralReason);
         em.flush();
         return existingDeferralReason;
+    }
+    
+    public DeferralReason findDeferralReasonByType(DeferralReasonType deferralReasonType)
+            throws NonUniqueResultException, NoResultException {
+
+        return em.createNamedQuery(
+                DeferralReasonNamedQueryConstants.NAME_FIND_DEFERRAL_REASON_BY_TYPE,
+                DeferralReason.class)
+                .setParameter("type", deferralReasonType)
+                .setParameter("deleted", false)
+                .getSingleResult();
     }
 }

--- a/src/repository/DonorDeferralRepository.java
+++ b/src/repository/DonorDeferralRepository.java
@@ -1,0 +1,24 @@
+package repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import model.donordeferral.DonorDeferral;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Repository
+public class DonorDeferralRepository {
+    
+    @PersistenceContext
+    private EntityManager entityManager;
+    
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void save(DonorDeferral donorDeferral) {
+        entityManager.persist(donorDeferral);
+    }
+
+}

--- a/src/service/ComponentCRUDService.java
+++ b/src/service/ComponentCRUDService.java
@@ -1,0 +1,26 @@
+package service;
+
+import model.component.ComponentStatus;
+import model.donor.Donor;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import repository.ComponentRepository;
+
+@Transactional
+@Service
+public class ComponentCRUDService {
+    
+    @Autowired
+    private ComponentRepository componentRepository;
+    
+    /**
+     * Change the status of components belonging to a donor from AVAILABLE to UNSAFE.
+     */
+    public void markComponentsBelongingToDonorAsUnsafe(Donor donor) {
+        componentRepository.updateComponentStatusForDonor(ComponentStatus.AVAILABLE, ComponentStatus.UNSAFE, donor);
+    }
+
+}

--- a/src/service/DateGeneratorService.java
+++ b/src/service/DateGeneratorService.java
@@ -1,0 +1,14 @@
+package service;
+
+import java.util.Date;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class DateGeneratorService {
+    
+    public Date generateDate() {
+        return new Date();
+    }
+
+}

--- a/src/service/DonorDeferralCRUDService.java
+++ b/src/service/DonorDeferralCRUDService.java
@@ -1,0 +1,50 @@
+package service;
+
+import java.util.Date;
+
+import model.donor.Donor;
+import model.donordeferral.DeferralReason;
+import model.donordeferral.DeferralReasonType;
+import model.donordeferral.DeferralType;
+import model.donordeferral.DonorDeferral;
+
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import repository.DeferralReasonRepository;
+import repository.DonorDeferralRepository;
+
+@Transactional
+@Service
+public class DonorDeferralCRUDService {
+    
+    private static final Logger LOGGER = Logger.getLogger(DonorDeferralCRUDService.class);
+    
+    public static final Date PERMANENT_DEFERRAL_DATE = new Date(4102444800000L); // 2100-01-01
+    
+    @Autowired
+    private DonorDeferralRepository donorDeferralRepository;
+    @Autowired
+    private DeferralReasonRepository deferralReasonRepository;
+    
+    public DonorDeferral createAutomatedUnsafeDeferralForDonor(Donor donor) {
+        LOGGER.info("Creating automated unsafe deferral for donor: " + donor);
+        
+        DonorDeferral donorDeferral = new DonorDeferral();
+        donorDeferral.setDeferralType(DeferralType.PERMANENT);
+        donorDeferral.setDeferredUntil(PERMANENT_DEFERRAL_DATE);
+        donorDeferral.setDeferredDonor(donor);
+        donorDeferral.setIsVoided(Boolean.FALSE);
+        
+        // Set deferral reason
+        DeferralReason deferralReason = deferralReasonRepository.findDeferralReasonByType(
+                DeferralReasonType.AUTOMATED_TTI_UNSAFE);
+        donorDeferral.setDeferralReason(deferralReason);
+        
+        donorDeferralRepository.save(donorDeferral);
+        return donorDeferral;
+    }
+
+}

--- a/src/service/TestBatchCRUDService.java
+++ b/src/service/TestBatchCRUDService.java
@@ -7,6 +7,7 @@ import model.bloodtesting.TTIStatus;
 import model.donation.Donation;
 import model.donationbatch.DonationBatch;
 import model.donor.Donor;
+import model.donordeferral.DeferralReasonType;
 import model.testbatch.TestBatch;
 import model.testbatch.TestBatchStatus;
 
@@ -60,7 +61,8 @@ public class TestBatchCRUDService {
             
             // Create deferrals for donors who have unsafe donations
             for (Donor donorToDefer : donorsToDefer) {
-                donorDeferralCRUDService.createAutomatedUnsafeDeferralForDonor(donorToDefer);
+                donorDeferralCRUDService.createDeferralForDonorWithDeferralReasonType(donorToDefer,
+                        DeferralReasonType.AUTOMATED_TTI_UNSAFE);
 
                 // Make sure that components belonging to this donor are marked as unsafe
                 componentCRUDService.markComponentsBelongingToDonorAsUnsafe(donorToDefer);

--- a/src/service/TestBatchCRUDService.java
+++ b/src/service/TestBatchCRUDService.java
@@ -26,6 +26,8 @@ public class TestBatchCRUDService {
     private PostDonationCounsellingCRUDService postDonationCounsellingCRUDService;
     @Autowired
     private DonorDeferralCRUDService donorDeferralCRUDService;
+    @Autowired
+    private ComponentCRUDService componentCRUDService;
 
     public void setTestBatchRepository(TestBatchRepository testBatchRepository) {
         this.testBatchRepository = testBatchRepository;
@@ -59,6 +61,9 @@ public class TestBatchCRUDService {
             // Create deferrals for donors who have unsafe donations
             for (Donor donorToDefer : donorsToDefer) {
                 donorDeferralCRUDService.createAutomatedUnsafeDeferralForDonor(donorToDefer);
+
+                // Make sure that components belonging to this donor are marked as unsafe
+                componentCRUDService.markComponentsBelongingToDonorAsUnsafe(donorToDefer);
             }
         }
 

--- a/src/viewmodel/DeferralReasonViewModel.java
+++ b/src/viewmodel/DeferralReasonViewModel.java
@@ -21,4 +21,8 @@ public class DeferralReasonViewModel {
     public Boolean getIsDeleted(){
         return deferralReason.getIsDeleted();
     }
+
+    public int getDefaultDuration() {
+        return deferralReason.getDefaultDuration();
+    }
 }

--- a/src/viewmodel/DeferralReasonViewModel.java
+++ b/src/viewmodel/DeferralReasonViewModel.java
@@ -23,7 +23,7 @@ public class DeferralReasonViewModel {
         return deferralReason.getIsDeleted();
     }
 
-    public int getDefaultDuration() {
+    public Integer getDefaultDuration() {
         return deferralReason.getDefaultDuration();
     }
     

--- a/src/viewmodel/DeferralReasonViewModel.java
+++ b/src/viewmodel/DeferralReasonViewModel.java
@@ -1,6 +1,7 @@
 package viewmodel;
 
 import model.donordeferral.DeferralReason;
+import model.donordeferral.DurationType;
 
 public class DeferralReasonViewModel {
 
@@ -24,5 +25,9 @@ public class DeferralReasonViewModel {
 
     public int getDefaultDuration() {
         return deferralReason.getDefaultDuration();
+    }
+    
+    public DurationType getDurationType() {
+        return deferralReason.getDurationType();
     }
 }

--- a/test/dataset/DeferralReasonRepositoryDataset.xml
+++ b/test/dataset/DeferralReasonRepositoryDataset.xml
@@ -1,10 +1,15 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <dataset>
-	<DeferralReason id="1" isDeleted="false" reason="High risk behaviour" defaultDuration="30" type="NORMAL" />
-	<DeferralReason id="2" isDeleted="false" reason="Low weight" defaultDuration="30" type="NORMAL" />
-	<DeferralReason id="3" isDeleted="false" reason="Low haemoglobin" defaultDuration="30" type="NORMAL" />
-	<DeferralReason id="4" isDeleted="false" reason="Other reasons" defaultDuration="30" type="NORMAL" />
-	<DeferralReason id="5" isDeleted="false"
-		reason="Other medical conditions" defaultDuration="30" type="NORMAL" />
-	<DeferralReason id="6" isDeleted="false" reason="Travel history" defaultDuration="30" type="NORMAL" />
+	<DeferralReason id="1" isDeleted="false" reason="High risk behaviour" defaultDuration="30" durationType="TEMPORARY"
+	       type="NORMAL" />
+	<DeferralReason id="2" isDeleted="false" reason="Low weight" defaultDuration="30" durationType="TEMPORARY"
+	       type="NORMAL" />
+	<DeferralReason id="3" isDeleted="false" reason="Low haemoglobin" defaultDuration="30" durationType="TEMPORARY"
+	       type="NORMAL" />
+	<DeferralReason id="4" isDeleted="false" reason="Other reasons" defaultDuration="30" durationType="TEMPORARY"
+	       type="NORMAL" />
+	<DeferralReason id="5" isDeleted="false" reason="Other medical conditions" defaultDuration="30"
+	       durationType="TEMPORARY" type="NORMAL" />
+	<DeferralReason id="6" isDeleted="false" reason="Travel history" defaultDuration="30" durationType="TEMPORARY"
+	       type="NORMAL" />
 </dataset>

--- a/test/dataset/DeferralReasonRepositoryDataset.xml
+++ b/test/dataset/DeferralReasonRepositoryDataset.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <dataset>
-	<DeferralReason id="1" isDeleted="false" reason="High risk behaviour" />
-	<DeferralReason id="2" isDeleted="false" reason="Low weight" />
-	<DeferralReason id="3" isDeleted="false" reason="Low haemoglobin" />
-	<DeferralReason id="4" isDeleted="false" reason="Other reasons" />
+	<DeferralReason id="1" isDeleted="false" reason="High risk behaviour" defaultDuration="30" />
+	<DeferralReason id="2" isDeleted="false" reason="Low weight" defaultDuration="30" />
+	<DeferralReason id="3" isDeleted="false" reason="Low haemoglobin" defaultDuration="30" />
+	<DeferralReason id="4" isDeleted="false" reason="Other reasons" defaultDuration="30" />
 	<DeferralReason id="5" isDeleted="false"
-		reason="Other medical conditions" />
-	<DeferralReason id="6" isDeleted="false" reason="Travel history" />
+		reason="Other medical conditions" defaultDuration="30" />
+	<DeferralReason id="6" isDeleted="false" reason="Travel history" defaultDuration="30" />
 </dataset>

--- a/test/dataset/DeferralReasonRepositoryDataset.xml
+++ b/test/dataset/DeferralReasonRepositoryDataset.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <dataset>
-	<DeferralReason id="1" isDeleted="false" reason="High risk behaviour" defaultDuration="30" />
-	<DeferralReason id="2" isDeleted="false" reason="Low weight" defaultDuration="30" />
-	<DeferralReason id="3" isDeleted="false" reason="Low haemoglobin" defaultDuration="30" />
-	<DeferralReason id="4" isDeleted="false" reason="Other reasons" defaultDuration="30" />
+	<DeferralReason id="1" isDeleted="false" reason="High risk behaviour" defaultDuration="30" type="NORMAL" />
+	<DeferralReason id="2" isDeleted="false" reason="Low weight" defaultDuration="30" type="NORMAL" />
+	<DeferralReason id="3" isDeleted="false" reason="Low haemoglobin" defaultDuration="30" type="NORMAL" />
+	<DeferralReason id="4" isDeleted="false" reason="Other reasons" defaultDuration="30" type="NORMAL" />
 	<DeferralReason id="5" isDeleted="false"
-		reason="Other medical conditions" defaultDuration="30" />
-	<DeferralReason id="6" isDeleted="false" reason="Travel history" defaultDuration="30" />
+		reason="Other medical conditions" defaultDuration="30" type="NORMAL" />
+	<DeferralReason id="6" isDeleted="false" reason="Travel history" defaultDuration="30" type="NORMAL" />
 </dataset>

--- a/test/dataset/DonorCommunicationsRepositoryDataset.xml
+++ b/test/dataset/DonorCommunicationsRepositoryDataset.xml
@@ -67,13 +67,13 @@
 		idNumber ="123" notes="notes" addressId ="1" contactId ="1"
 		donorPanel_id="1" createdBy_id="1" lastUpdatedBy_id="1" dueToDonate="${yesterday}"/>
 			
-	<deferralreason id="1" isDeleted="0" reason="High risk behaviour" />
-	<deferralreason id="2" isDeleted="0" reason="Low weight" />
-	<deferralreason id="3" isDeleted="0" reason="Low haemoglobin" />
-	<deferralreason id="4" isDeleted="0" reason="Other reasons" />
-	<deferralreason id="5" isDeleted="0" reason="Other medical conditions" />
-	<deferralreason id="6" isDeleted="0" reason="Travel history" />
-	<deferralreason id="7" isDeleted="1" reason="Test Deleted Deferal" />
+	<deferralreason id="1" isDeleted="0" reason="High risk behaviour" defaultDuration="30" />
+	<deferralreason id="2" isDeleted="0" reason="Low weight" defaultDuration="30" />
+	<deferralreason id="3" isDeleted="0" reason="Low haemoglobin" defaultDuration="30" />
+	<deferralreason id="4" isDeleted="0" reason="Other reasons" defaultDuration="30" />
+	<deferralreason id="5" isDeleted="0" reason="Other medical conditions" defaultDuration="30" />
+	<deferralreason id="6" isDeleted="0" reason="Travel history" defaultDuration="30" />
+	<deferralreason id="7" isDeleted="1" reason="Test Deleted Deferal" defaultDuration="30" />
 	
 	<donordeferral id="1" deferralReasonText="" createdDate="${today}"
 		deferredUntil="${sixMonthsAhead}" deferralReason_id="1" createdBy_id="1"

--- a/test/dataset/DonorCommunicationsRepositoryDataset.xml
+++ b/test/dataset/DonorCommunicationsRepositoryDataset.xml
@@ -67,25 +67,25 @@
 		idNumber ="123" notes="notes" addressId ="1" contactId ="1"
 		donorPanel_id="1" createdBy_id="1" lastUpdatedBy_id="1" dueToDonate="${yesterday}"/>
 			
-	<deferralreason id="1" isDeleted="0" reason="High risk behaviour" defaultDuration="30" />
-	<deferralreason id="2" isDeleted="0" reason="Low weight" defaultDuration="30" />
-	<deferralreason id="3" isDeleted="0" reason="Low haemoglobin" defaultDuration="30" />
-	<deferralreason id="4" isDeleted="0" reason="Other reasons" defaultDuration="30" />
-	<deferralreason id="5" isDeleted="0" reason="Other medical conditions" defaultDuration="30" />
-	<deferralreason id="6" isDeleted="0" reason="Travel history" defaultDuration="30" />
-	<deferralreason id="7" isDeleted="1" reason="Test Deleted Deferal" defaultDuration="30" />
+	<deferralreason id="1" isDeleted="0" reason="High risk behaviour" defaultDuration="30" type="NORMAL" />
+	<deferralreason id="2" isDeleted="0" reason="Low weight" defaultDuration="30" type="NORMAL" />
+	<deferralreason id="3" isDeleted="0" reason="Low haemoglobin" defaultDuration="30" type="NORMAL" />
+	<deferralreason id="4" isDeleted="0" reason="Other reasons" defaultDuration="30" type="NORMAL" />
+	<deferralreason id="5" isDeleted="0" reason="Other medical conditions" defaultDuration="30" type="NORMAL" />
+	<deferralreason id="6" isDeleted="0" reason="Travel history" defaultDuration="30" type="NORMAL" />
+	<deferralreason id="7" isDeleted="1" reason="Test Deleted Deferal" defaultDuration="30" type="NORMAL" />
 	
 	<donordeferral id="1" deferralReasonText="" createdDate="${today}"
 		deferredUntil="${sixMonthsAhead}" deferralReason_id="1" createdBy_id="1"
-		deferredDonor_id="1"/>
+		deferredDonor_id="1" deferralType="TEMPORARY" />
 	<donordeferral id="2" deferralReasonText="" createdDate="${oneMonthAgo}"
 		deferredUntil="${twoWeeksAgo}" deferralReason_id="1" createdBy_id="1"
-		deferredDonor_id="1"/>
+		deferredDonor_id="1" deferralType="TEMPORARY" />
 	<donordeferral id="3" deferralReasonText="" createdDate="${oneMonthAgo}"
 		deferredUntil="${twoWeeksAgo}" deferralReason_id="1" createdBy_id="1"
-		deferredDonor_id="3"/>
+		deferredDonor_id="3" deferralType="TEMPORARY" />
 	<donordeferral id="4" deferralReasonText="" createdDate="${oneMonthAgo}"
 		deferredUntil="${twoWeeksAgo}" deferralReason_id="1" createdBy_id="1"
-		deferredDonor_id="4"/>
+		deferredDonor_id="4" deferralType="TEMPORARY" />
 	 	
 </dataset>

--- a/test/dataset/DonorCommunicationsRepositoryDataset.xml
+++ b/test/dataset/DonorCommunicationsRepositoryDataset.xml
@@ -67,25 +67,32 @@
 		idNumber ="123" notes="notes" addressId ="1" contactId ="1"
 		donorPanel_id="1" createdBy_id="1" lastUpdatedBy_id="1" dueToDonate="${yesterday}"/>
 			
-	<deferralreason id="1" isDeleted="0" reason="High risk behaviour" defaultDuration="30" type="NORMAL" />
-	<deferralreason id="2" isDeleted="0" reason="Low weight" defaultDuration="30" type="NORMAL" />
-	<deferralreason id="3" isDeleted="0" reason="Low haemoglobin" defaultDuration="30" type="NORMAL" />
-	<deferralreason id="4" isDeleted="0" reason="Other reasons" defaultDuration="30" type="NORMAL" />
-	<deferralreason id="5" isDeleted="0" reason="Other medical conditions" defaultDuration="30" type="NORMAL" />
-	<deferralreason id="6" isDeleted="0" reason="Travel history" defaultDuration="30" type="NORMAL" />
-	<deferralreason id="7" isDeleted="1" reason="Test Deleted Deferal" defaultDuration="30" type="NORMAL" />
+	<deferralreason id="1" isDeleted="0" reason="High risk behaviour" defaultDuration="30" durationType="TEMPORARY"
+	       type="NORMAL" />
+	<deferralreason id="2" isDeleted="0" reason="Low weight" defaultDuration="30" durationType="TEMPORARY"
+	       type="NORMAL" />
+	<deferralreason id="3" isDeleted="0" reason="Low haemoglobin" defaultDuration="30" durationType="TEMPORARY"
+	       type="NORMAL" />
+	<deferralreason id="4" isDeleted="0" reason="Other reasons" defaultDuration="30" durationType="TEMPORARY"
+	       type="NORMAL" />
+	<deferralreason id="5" isDeleted="0" reason="Other medical conditions" defaultDuration="30" durationType="TEMPORARY"
+	       type="NORMAL" />
+	<deferralreason id="6" isDeleted="0" reason="Travel history" defaultDuration="30" durationType="TEMPORARY"
+	       type="NORMAL" />
+	<deferralreason id="7" isDeleted="1" reason="Test Deleted Deferal" defaultDuration="30" durationType="TEMPORARY"
+	       type="NORMAL" />
 	
 	<donordeferral id="1" deferralReasonText="" createdDate="${today}"
 		deferredUntil="${sixMonthsAhead}" deferralReason_id="1" createdBy_id="1"
-		deferredDonor_id="1" deferralType="TEMPORARY" />
+		deferredDonor_id="1" />
 	<donordeferral id="2" deferralReasonText="" createdDate="${oneMonthAgo}"
 		deferredUntil="${twoWeeksAgo}" deferralReason_id="1" createdBy_id="1"
-		deferredDonor_id="1" deferralType="TEMPORARY" />
+		deferredDonor_id="1" />
 	<donordeferral id="3" deferralReasonText="" createdDate="${oneMonthAgo}"
 		deferredUntil="${twoWeeksAgo}" deferralReason_id="1" createdBy_id="1"
-		deferredDonor_id="3" deferralType="TEMPORARY" />
+		deferredDonor_id="3" />
 	<donordeferral id="4" deferralReasonText="" createdDate="${oneMonthAgo}"
 		deferredUntil="${twoWeeksAgo}" deferralReason_id="1" createdBy_id="1"
-		deferredDonor_id="4" deferralType="TEMPORARY" />
+		deferredDonor_id="4" />
 	 	
 </dataset>

--- a/test/dataset/DonorRepositoryDataset.xml
+++ b/test/dataset/DonorRepositoryDataset.xml
@@ -239,14 +239,14 @@
 	<genericconfig id="48" propertyName="lotRelease"
 		propertyOwner="labsetup" propertyValue="TRUE" />
 
-	<deferralreason id="1" isDeleted="0" reason="High risk behaviour" />
-	<deferralreason id="2" isDeleted="0" reason="Low weight" />
-	<deferralreason id="3" isDeleted="0" reason="Low haemoglobin" />
-	<deferralreason id="4" isDeleted="0" reason="Other reasons" />
+	<deferralreason id="1" isDeleted="0" reason="High risk behaviour" defaultDuration="30" />
+	<deferralreason id="2" isDeleted="0" reason="Low weight" defaultDuration="30" />
+	<deferralreason id="3" isDeleted="0" reason="Low haemoglobin" defaultDuration="30" />
+	<deferralreason id="4" isDeleted="0" reason="Other reasons" defaultDuration="30" />
 	<deferralreason id="5" isDeleted="0"
-		reason="Other medical conditions" />
-	<deferralreason id="6" isDeleted="0" reason="Travel history" />
-	<deferralreason id="7" isDeleted="1" reason="Test Deleted Deferal" />
+		reason="Other medical conditions" defaultDuration="30" />
+	<deferralreason id="6" isDeleted="0" reason="Travel history" defaultDuration="30" />
+	<deferralreason id="7" isDeleted="1" reason="Test Deleted Deferal" defaultDuration="30" />
 
 	<formfield id="1" autoGenerate="1" canBeOptional="0"
 		defaultDisplayName="Donor #" field="donorNumber" form="donor" hidden="0"

--- a/test/dataset/DonorRepositoryDataset.xml
+++ b/test/dataset/DonorRepositoryDataset.xml
@@ -239,14 +239,14 @@
 	<genericconfig id="48" propertyName="lotRelease"
 		propertyOwner="labsetup" propertyValue="TRUE" />
 
-	<deferralreason id="1" isDeleted="0" reason="High risk behaviour" defaultDuration="30" />
-	<deferralreason id="2" isDeleted="0" reason="Low weight" defaultDuration="30" />
-	<deferralreason id="3" isDeleted="0" reason="Low haemoglobin" defaultDuration="30" />
-	<deferralreason id="4" isDeleted="0" reason="Other reasons" defaultDuration="30" />
+	<deferralreason id="1" isDeleted="0" reason="High risk behaviour" defaultDuration="30" type="NORMAL" />
+	<deferralreason id="2" isDeleted="0" reason="Low weight" defaultDuration="30" type="NORMAL" />
+	<deferralreason id="3" isDeleted="0" reason="Low haemoglobin" defaultDuration="30" type="NORMAL" />
+	<deferralreason id="4" isDeleted="0" reason="Other reasons" defaultDuration="30" type="NORMAL" />
 	<deferralreason id="5" isDeleted="0"
-		reason="Other medical conditions" defaultDuration="30" />
-	<deferralreason id="6" isDeleted="0" reason="Travel history" defaultDuration="30" />
-	<deferralreason id="7" isDeleted="1" reason="Test Deleted Deferal" defaultDuration="30" />
+		reason="Other medical conditions" defaultDuration="30" type="NORMAL" />
+	<deferralreason id="6" isDeleted="0" reason="Travel history" defaultDuration="30" type="NORMAL" />
+	<deferralreason id="7" isDeleted="1" reason="Test Deleted Deferal" defaultDuration="30" type="NORMAL" />
 
 	<formfield id="1" autoGenerate="1" canBeOptional="0"
 		defaultDisplayName="Donor #" field="donorNumber" form="donor" hidden="0"
@@ -255,22 +255,22 @@
 
 	<donordeferral id="1" deferralReasonText="" createdDate="${DateDeferredOn}"
 		deferredUntil="${DateDeferredUnit}" deferralReason_id="2" createdBy_id="1"
-		deferredDonor_id="1" isVoided="false" />
+		deferredDonor_id="1" isVoided="false" deferralType="TEMPORARY" />
 	<donordeferral id="2" deferralReasonText="" createdDate="2014-03-01"
 		deferredUntil="2014-05-14" deferralReason_id="2" createdBy_id="1"
-		deferredDonor_id="1" isVoided="false" />
+		deferredDonor_id="1" isVoided="false" deferralType="TEMPORARY" />
 	<donordeferral id="3" deferralReasonText="" createdDate="2014-01-11"
 		deferredUntil="2014-08-22" deferralReason_id="2" createdBy_id="1"
-		deferredDonor_id="1" isVoided="false" />
+		deferredDonor_id="1" isVoided="false" deferralType="TEMPORARY" />
 	<donordeferral id="4" deferralReasonText="" createdDate="2014-01-11"
 		deferredUntil="2014-02-22" deferralReason_id="2" createdBy_id="1"
-		deferredDonor_id="4" isVoided="false" />
+		deferredDonor_id="4" isVoided="false" deferralType="TEMPORARY" />
 	<donordeferral id="5" deferralReasonText=""
 		createdDate="${DateDeferredOn}" deferredUntil="${DateDeferredOn}"
-		deferralReason_id="2" createdBy_id="1" deferredDonor_id="4" isVoided="false" />
+		deferralReason_id="2" createdBy_id="1" deferredDonor_id="4" isVoided="false" deferralType="TEMPORARY" />
 	<donordeferral id="6" deferralReasonText=""
 		createdDate="${DateDeferredOn}" deferredUntil="${DateDeferredUnit}"
-		deferralReason_id="2" createdBy_id="1" deferredDonor_id="6" isVoided="false" />
+		deferralReason_id="2" createdBy_id="1" deferredDonor_id="6" isVoided="false" deferralType="TEMPORARY" />
 
 	<PreferredLanguage id="1" preferredLanguage = "English"/>
 	<PreferredLanguage id="2" preferredLanguage = "English"/> 

--- a/test/dataset/DonorRepositoryDataset.xml
+++ b/test/dataset/DonorRepositoryDataset.xml
@@ -239,14 +239,20 @@
 	<genericconfig id="48" propertyName="lotRelease"
 		propertyOwner="labsetup" propertyValue="TRUE" />
 
-	<deferralreason id="1" isDeleted="0" reason="High risk behaviour" defaultDuration="30" type="NORMAL" />
-	<deferralreason id="2" isDeleted="0" reason="Low weight" defaultDuration="30" type="NORMAL" />
-	<deferralreason id="3" isDeleted="0" reason="Low haemoglobin" defaultDuration="30" type="NORMAL" />
-	<deferralreason id="4" isDeleted="0" reason="Other reasons" defaultDuration="30" type="NORMAL" />
-	<deferralreason id="5" isDeleted="0"
-		reason="Other medical conditions" defaultDuration="30" type="NORMAL" />
-	<deferralreason id="6" isDeleted="0" reason="Travel history" defaultDuration="30" type="NORMAL" />
-	<deferralreason id="7" isDeleted="1" reason="Test Deleted Deferal" defaultDuration="30" type="NORMAL" />
+	<deferralreason id="1" isDeleted="0" reason="High risk behaviour" defaultDuration="30" durationType="TEMPORARY"
+	       type="NORMAL" />
+	<deferralreason id="2" isDeleted="0" reason="Low weight" defaultDuration="30" durationType="TEMPORARY"
+	       type="NORMAL" />
+	<deferralreason id="3" isDeleted="0" reason="Low haemoglobin" defaultDuration="30" durationType="TEMPORARY"
+	       type="NORMAL" />
+	<deferralreason id="4" isDeleted="0" reason="Other reasons" defaultDuration="30" durationType="TEMPORARY"
+	       type="NORMAL" />
+	<deferralreason id="5" isDeleted="0" reason="Other medical conditions" defaultDuration="30" durationType="TEMPORARY"
+	       type="NORMAL" />
+	<deferralreason id="6" isDeleted="0" reason="Travel history" defaultDuration="30" durationType="TEMPORARY"
+	       type="NORMAL" />
+	<deferralreason id="7" isDeleted="1" reason="Test Deleted Deferal" defaultDuration="30" durationType="TEMPORARY"
+	       type="NORMAL" />
 
 	<formfield id="1" autoGenerate="1" canBeOptional="0"
 		defaultDisplayName="Donor #" field="donorNumber" form="donor" hidden="0"
@@ -255,22 +261,22 @@
 
 	<donordeferral id="1" deferralReasonText="" createdDate="${DateDeferredOn}"
 		deferredUntil="${DateDeferredUnit}" deferralReason_id="2" createdBy_id="1"
-		deferredDonor_id="1" isVoided="false" deferralType="TEMPORARY" />
+		deferredDonor_id="1" isVoided="false" />
 	<donordeferral id="2" deferralReasonText="" createdDate="2014-03-01"
 		deferredUntil="2014-05-14" deferralReason_id="2" createdBy_id="1"
-		deferredDonor_id="1" isVoided="false" deferralType="TEMPORARY" />
+		deferredDonor_id="1" isVoided="false" />
 	<donordeferral id="3" deferralReasonText="" createdDate="2014-01-11"
 		deferredUntil="2014-08-22" deferralReason_id="2" createdBy_id="1"
-		deferredDonor_id="1" isVoided="false" deferralType="TEMPORARY" />
+		deferredDonor_id="1" isVoided="false" />
 	<donordeferral id="4" deferralReasonText="" createdDate="2014-01-11"
 		deferredUntil="2014-02-22" deferralReason_id="2" createdBy_id="1"
-		deferredDonor_id="4" isVoided="false" deferralType="TEMPORARY" />
+		deferredDonor_id="4" isVoided="false" />
 	<donordeferral id="5" deferralReasonText=""
 		createdDate="${DateDeferredOn}" deferredUntil="${DateDeferredOn}"
-		deferralReason_id="2" createdBy_id="1" deferredDonor_id="4" isVoided="false" deferralType="TEMPORARY" />
+		deferralReason_id="2" createdBy_id="1" deferredDonor_id="4" isVoided="false" />
 	<donordeferral id="6" deferralReasonText=""
 		createdDate="${DateDeferredOn}" deferredUntil="${DateDeferredUnit}"
-		deferralReason_id="2" createdBy_id="1" deferredDonor_id="6" isVoided="false" deferralType="TEMPORARY" />
+		deferralReason_id="2" createdBy_id="1" deferredDonor_id="6" isVoided="false" />
 
 	<PreferredLanguage id="1" preferredLanguage = "English"/>
 	<PreferredLanguage id="2" preferredLanguage = "English"/> 

--- a/test/helpers/builders/ComponentBuilder.java
+++ b/test/helpers/builders/ComponentBuilder.java
@@ -1,0 +1,41 @@
+package helpers.builders;
+
+import helpers.persisters.AbstractEntityPersister;
+import helpers.persisters.ComponentPersister;
+import model.component.Component;
+import model.component.ComponentStatus;
+import model.donation.Donation;
+
+public class ComponentBuilder extends AbstractEntityBuilder<Component> {
+    
+    private ComponentStatus status;
+    private Donation donation;
+
+    public ComponentBuilder withStatus(ComponentStatus status) {
+        this.status = status;
+        return this;
+    }
+    
+    public ComponentBuilder withDonation(Donation donation) {
+        this.donation = donation;
+        return this;
+    }
+
+    @Override
+    public Component build() {
+        Component component = new Component();
+        component.setStatus(status);
+        component.setDonation(donation);
+        return component;
+    }
+    
+    @Override
+    public AbstractEntityPersister<Component> getPersister() {
+        return new ComponentPersister();
+    }
+
+    public static ComponentBuilder aComponent() {
+        return new ComponentBuilder();
+    }
+
+}

--- a/test/helpers/builders/DeferralReasonBackingFormBuilder.java
+++ b/test/helpers/builders/DeferralReasonBackingFormBuilder.java
@@ -1,12 +1,14 @@
 package helpers.builders;
 
 import model.donordeferral.DeferralReason;
+import model.donordeferral.DurationType;
 import backingform.DeferralReasonBackingForm;
 
 public class DeferralReasonBackingFormBuilder {
     
     private DeferralReason deferralReason;
     private int defaultDuration;
+    private DurationType durationType;
 
     public DeferralReasonBackingFormBuilder withDeferralReason(DeferralReason deferralReason) {
         this.deferralReason = deferralReason;
@@ -18,10 +20,16 @@ public class DeferralReasonBackingFormBuilder {
         return this;
     }
     
+    public DeferralReasonBackingFormBuilder withDurationType(DurationType durationType) {
+        this.durationType = durationType;
+        return this;
+    }
+    
     public DeferralReasonBackingForm build() {
         DeferralReasonBackingForm backingForm = new DeferralReasonBackingForm();
         backingForm.setDeferralReason(deferralReason);
         backingForm.setDefaultDuration(defaultDuration);
+        backingForm.setDurationType(durationType);
         return backingForm;
     }
     

--- a/test/helpers/builders/DeferralReasonBackingFormBuilder.java
+++ b/test/helpers/builders/DeferralReasonBackingFormBuilder.java
@@ -1,0 +1,32 @@
+package helpers.builders;
+
+import model.donordeferral.DeferralReason;
+import backingform.DeferralReasonBackingForm;
+
+public class DeferralReasonBackingFormBuilder {
+    
+    private DeferralReason deferralReason;
+    private int defaultDuration;
+
+    public DeferralReasonBackingFormBuilder withDeferralReason(DeferralReason deferralReason) {
+        this.deferralReason = deferralReason;
+        return this;
+    }
+    
+    public DeferralReasonBackingFormBuilder withDefaultDuration(int defaultDuration) {
+        this.defaultDuration = defaultDuration;
+        return this;
+    }
+    
+    public DeferralReasonBackingForm build() {
+        DeferralReasonBackingForm backingForm = new DeferralReasonBackingForm();
+        backingForm.setDeferralReason(deferralReason);
+        backingForm.setDefaultDuration(defaultDuration);
+        return backingForm;
+    }
+    
+    public static DeferralReasonBackingFormBuilder aDeferralReasonBackingForm() {
+        return new DeferralReasonBackingFormBuilder();
+    }
+
+}

--- a/test/helpers/builders/DeferralReasonBuilder.java
+++ b/test/helpers/builders/DeferralReasonBuilder.java
@@ -1,0 +1,17 @@
+package helpers.builders;
+
+import model.donordeferral.DeferralReason;
+
+public class DeferralReasonBuilder extends AbstractEntityBuilder<DeferralReason> {
+
+    @Override
+    public DeferralReason build() {
+        DeferralReason deferralReason = new DeferralReason();
+        return deferralReason;
+    }
+    
+    public static DeferralReasonBuilder aDeferralReason() {
+        return new DeferralReasonBuilder();
+    }
+
+}

--- a/test/helpers/builders/DeferralReasonBuilder.java
+++ b/test/helpers/builders/DeferralReasonBuilder.java
@@ -2,11 +2,14 @@ package helpers.builders;
 
 import model.donordeferral.DeferralReason;
 import model.donordeferral.DeferralReasonType;
+import model.donordeferral.DurationType;
 
 public class DeferralReasonBuilder extends AbstractEntityBuilder<DeferralReason> {
     
     private DeferralReasonType type;
     private Boolean deleted;
+    private DurationType durationType = DurationType.TEMPORARY;
+    private int defaultDuration;
 
     public DeferralReasonBuilder withType(DeferralReasonType type) {
         this.type = type;
@@ -22,12 +25,24 @@ public class DeferralReasonBuilder extends AbstractEntityBuilder<DeferralReason>
         deleted = true;
         return this;
     }
+    
+    public DeferralReasonBuilder withDurationType(DurationType durationType) {
+        this.durationType = durationType;
+        return this;
+    }
+    
+    public DeferralReasonBuilder withDefaultDuration(int defaultDuration) {
+        this.defaultDuration = defaultDuration;
+        return this;
+    }
 
     @Override
     public DeferralReason build() {
         DeferralReason deferralReason = new DeferralReason();
         deferralReason.setType(type);
         deferralReason.setIsDeleted(deleted);
+        deferralReason.setDurationType(durationType);
+        deferralReason.setDefaultDuration(defaultDuration);
         return deferralReason;
     }
     

--- a/test/helpers/builders/DeferralReasonBuilder.java
+++ b/test/helpers/builders/DeferralReasonBuilder.java
@@ -9,7 +9,7 @@ public class DeferralReasonBuilder extends AbstractEntityBuilder<DeferralReason>
     private DeferralReasonType type;
     private Boolean deleted;
     private DurationType durationType = DurationType.TEMPORARY;
-    private int defaultDuration;
+    private Integer defaultDuration;
 
     public DeferralReasonBuilder withType(DeferralReasonType type) {
         this.type = type;
@@ -31,7 +31,7 @@ public class DeferralReasonBuilder extends AbstractEntityBuilder<DeferralReason>
         return this;
     }
     
-    public DeferralReasonBuilder withDefaultDuration(int defaultDuration) {
+    public DeferralReasonBuilder withDefaultDuration(Integer defaultDuration) {
         this.defaultDuration = defaultDuration;
         return this;
     }

--- a/test/helpers/builders/DeferralReasonBuilder.java
+++ b/test/helpers/builders/DeferralReasonBuilder.java
@@ -1,12 +1,33 @@
 package helpers.builders;
 
 import model.donordeferral.DeferralReason;
+import model.donordeferral.DeferralReasonType;
 
 public class DeferralReasonBuilder extends AbstractEntityBuilder<DeferralReason> {
+    
+    private DeferralReasonType type;
+    private Boolean deleted;
+
+    public DeferralReasonBuilder withType(DeferralReasonType type) {
+        this.type = type;
+        return this;
+    }
+    
+    public DeferralReasonBuilder thatIsNotDeleted() {
+        deleted = false;
+        return this;
+    }
+    
+    public DeferralReasonBuilder thatIsDeleted() {
+        deleted = true;
+        return this;
+    }
 
     @Override
     public DeferralReason build() {
         DeferralReason deferralReason = new DeferralReason();
+        deferralReason.setType(type);
+        deferralReason.setIsDeleted(deleted);
         return deferralReason;
     }
     

--- a/test/helpers/builders/DonorDeferralBuilder.java
+++ b/test/helpers/builders/DonorDeferralBuilder.java
@@ -1,0 +1,58 @@
+package helpers.builders;
+
+import java.util.Date;
+
+import model.donor.Donor;
+import model.donordeferral.DeferralReason;
+import model.donordeferral.DeferralType;
+import model.donordeferral.DonorDeferral;
+
+public class DonorDeferralBuilder extends AbstractEntityBuilder<DonorDeferral> {
+    
+    private Donor deferredDonor;
+    private DeferralReason deferralReason;
+    private DeferralType deferralType;
+    private Date deferredUntil;
+    private Boolean voided;
+
+    public DonorDeferralBuilder withDeferredDonor(Donor deferredDonor) {
+        this.deferredDonor = deferredDonor;
+        return this;
+    }
+
+    public DonorDeferralBuilder withDeferralReason(DeferralReason deferralReason) {
+        this.deferralReason = deferralReason;
+        return this;
+    }
+    
+    public DonorDeferralBuilder withDeferralType(DeferralType deferralType) {
+        this.deferralType = deferralType;
+        return this;
+    }
+    
+    public DonorDeferralBuilder withDeferredUntil(Date deferredUntil) {
+        this.deferredUntil = deferredUntil;
+        return this;
+    }
+    
+    public DonorDeferralBuilder thatIsNotVoided() {
+        voided = false;
+        return this;
+    }
+
+    @Override
+    public DonorDeferral build() {
+        DonorDeferral donorDeferral = new DonorDeferral();
+        donorDeferral.setDeferredDonor(deferredDonor);
+        donorDeferral.setDeferralReason(deferralReason);
+        donorDeferral.setDeferralType(deferralType);
+        donorDeferral.setDeferredUntil(deferredUntil);
+        donorDeferral.setIsVoided(voided);
+        return donorDeferral;
+    }
+    
+    public static DonorDeferralBuilder aDonorDeferral() {
+        return new DonorDeferralBuilder();
+    }
+
+}

--- a/test/helpers/builders/DonorDeferralBuilder.java
+++ b/test/helpers/builders/DonorDeferralBuilder.java
@@ -4,14 +4,12 @@ import java.util.Date;
 
 import model.donor.Donor;
 import model.donordeferral.DeferralReason;
-import model.donordeferral.DeferralType;
 import model.donordeferral.DonorDeferral;
 
 public class DonorDeferralBuilder extends AbstractEntityBuilder<DonorDeferral> {
     
     private Donor deferredDonor;
     private DeferralReason deferralReason;
-    private DeferralType deferralType;
     private Date deferredUntil;
     private Boolean voided;
 
@@ -22,11 +20,6 @@ public class DonorDeferralBuilder extends AbstractEntityBuilder<DonorDeferral> {
 
     public DonorDeferralBuilder withDeferralReason(DeferralReason deferralReason) {
         this.deferralReason = deferralReason;
-        return this;
-    }
-    
-    public DonorDeferralBuilder withDeferralType(DeferralType deferralType) {
-        this.deferralType = deferralType;
         return this;
     }
     
@@ -45,7 +38,6 @@ public class DonorDeferralBuilder extends AbstractEntityBuilder<DonorDeferral> {
         DonorDeferral donorDeferral = new DonorDeferral();
         donorDeferral.setDeferredDonor(deferredDonor);
         donorDeferral.setDeferralReason(deferralReason);
-        donorDeferral.setDeferralType(deferralType);
         donorDeferral.setDeferredUntil(deferredUntil);
         donorDeferral.setIsVoided(voided);
         return donorDeferral;

--- a/test/helpers/matchers/DonorDeferralMatcher.java
+++ b/test/helpers/matchers/DonorDeferralMatcher.java
@@ -20,7 +20,6 @@ public class DonorDeferralMatcher extends TypeSafeMatcher<DonorDeferral> {
         description.appendText("A donor deferral with the following state:")
                 .appendText("\nDonor: ").appendValue(expected.getDeferredDonor())
                 .appendText("\nDeferral reason: ").appendValue(expected.getDeferralReason())
-                .appendText("\nDeferral type: ").appendValue(expected.getDeferralType())
                 .appendText("\nDeferred until: ").appendValue(expected.getDeferredUntil())
                 .appendText("\nVoided: ").appendValue(expected.getIsVoided());
     }
@@ -29,7 +28,6 @@ public class DonorDeferralMatcher extends TypeSafeMatcher<DonorDeferral> {
     public boolean matchesSafely(DonorDeferral actual) {
         return Objects.equals(actual.getDeferredDonor(), expected.getDeferredDonor()) &&
                 Objects.equals(actual.getDeferralReason(), expected.getDeferralReason()) &&
-                Objects.equals(actual.getDeferralType(), expected.getDeferralType()) &&
                 Objects.equals(actual.getDeferredUntil(), expected.getDeferredUntil()) &&
                 Objects.equals(actual.getIsVoided(), expected.getIsVoided());
     }

--- a/test/helpers/matchers/DonorDeferralMatcher.java
+++ b/test/helpers/matchers/DonorDeferralMatcher.java
@@ -1,0 +1,41 @@
+package helpers.matchers;
+
+import java.util.Objects;
+
+import model.donordeferral.DonorDeferral;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+public class DonorDeferralMatcher extends TypeSafeMatcher<DonorDeferral> {
+    
+    private DonorDeferral expected;
+    
+    public DonorDeferralMatcher(DonorDeferral expected) {
+        this.expected = expected;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("A donor deferral with the following state:")
+                .appendText("\nDonor: ").appendValue(expected.getDeferredDonor())
+                .appendText("\nDeferral reason: ").appendValue(expected.getDeferralReason())
+                .appendText("\nDeferral type: ").appendValue(expected.getDeferralType())
+                .appendText("\nDeferred until: ").appendValue(expected.getDeferredUntil())
+                .appendText("\nVoided: ").appendValue(expected.getIsVoided());
+    }
+
+    @Override
+    public boolean matchesSafely(DonorDeferral actual) {
+        return Objects.equals(actual.getDeferredDonor(), expected.getDeferredDonor()) &&
+                Objects.equals(actual.getDeferralReason(), expected.getDeferralReason()) &&
+                Objects.equals(actual.getDeferralType(), expected.getDeferralType()) &&
+                Objects.equals(actual.getDeferredUntil(), expected.getDeferredUntil()) &&
+                Objects.equals(actual.getIsVoided(), expected.getIsVoided());
+    }
+    
+    public static DonorDeferralMatcher hasSameStateAsDonorDeferral(DonorDeferral expected) {
+        return new DonorDeferralMatcher(expected);
+    }
+
+}

--- a/test/helpers/persisters/ComponentPersister.java
+++ b/test/helpers/persisters/ComponentPersister.java
@@ -1,0 +1,19 @@
+package helpers.persisters;
+
+import static helpers.persisters.EntityPersisterFactory.aDonationPersister;
+
+import javax.persistence.EntityManager;
+
+import model.component.Component;
+
+public class ComponentPersister extends AbstractEntityPersister<Component> {
+
+    @Override
+    public Component deepPersist(Component component, EntityManager entityManager) {
+        if (component.getDonation() != null) {
+            aDonationPersister().deepPersist(component.getDonation(), entityManager);
+        }
+        return persist(component, entityManager);
+    }
+
+}

--- a/test/repository/ComponentRepositoryTests.java
+++ b/test/repository/ComponentRepositoryTests.java
@@ -14,6 +14,7 @@ import model.component.ComponentStatus;
 import model.donor.Donor;
 
 import org.junit.Test;
+import org.junit.Ignore;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import suites.ContextDependentTestSuite;
@@ -26,6 +27,7 @@ public class ComponentRepositoryTests extends ContextDependentTestSuite {
     private ComponentRepository componentRepository;
     
     @Test
+    @Ignore
     public void testUpdateComponentStatusForDonor_shouldOnlyUpdateMatchingComponents() {
         ComponentStatus oldStatus = ComponentStatus.AVAILABLE;
         ComponentStatus newStatus = ComponentStatus.UNSAFE;

--- a/test/repository/ComponentRepositoryTests.java
+++ b/test/repository/ComponentRepositoryTests.java
@@ -1,0 +1,69 @@
+package repository;
+
+import static helpers.builders.ComponentBuilder.aComponent;
+import static helpers.builders.DonationBuilder.aDonation;
+import static helpers.builders.DonorBuilder.aDonor;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import model.component.Component;
+import model.component.ComponentStatus;
+import model.donor.Donor;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import suites.ContextDependentTestSuite;
+
+public class ComponentRepositoryTests extends ContextDependentTestSuite {
+    
+    @PersistenceContext
+    private EntityManager entityManager;
+    @Autowired
+    private ComponentRepository componentRepository;
+    
+    @Test
+    public void testUpdateComponentStatusForDonor_shouldOnlyUpdateMatchingComponents() {
+        ComponentStatus oldStatus = ComponentStatus.AVAILABLE;
+        ComponentStatus newStatus = ComponentStatus.UNSAFE;
+        Donor donor = aDonor().build();
+        
+        Component firstComponentToUpdate = aComponent()
+                .withStatus(oldStatus)
+                .withDonation(aDonation().withDonor(donor).build())
+                .buildAndPersist(entityManager);
+        
+        Component secondComponentToUpdate = aComponent()
+                .withStatus(oldStatus)
+                .withDonation(aDonation().withDonor(donor).build())
+                .buildAndPersist(entityManager);
+
+        Component componentExcludedByStatus = aComponent()
+                .withStatus(ComponentStatus.USED)
+                .withDonation(aDonation().withDonor(donor).build())
+                .buildAndPersist(entityManager);
+
+        Component componentExcludedByDonor = aComponent()
+                .withStatus(oldStatus)
+                .withDonation(aDonation()
+                        .withDonor(aDonor().build())
+                        .build())
+                .buildAndPersist(entityManager);
+        
+        componentRepository.updateComponentStatusForDonor(oldStatus, newStatus, donor);
+        
+        entityManager.refresh(firstComponentToUpdate);
+        entityManager.refresh(secondComponentToUpdate);
+        entityManager.refresh(componentExcludedByStatus);
+        entityManager.refresh(componentExcludedByDonor);
+        
+        assertThat(firstComponentToUpdate.getStatus(), is(newStatus));
+        assertThat(secondComponentToUpdate.getStatus(), is(newStatus));
+        assertThat(componentExcludedByStatus.getStatus(), is(ComponentStatus.USED));
+        assertThat(componentExcludedByDonor.getStatus(), is(oldStatus));
+    }
+
+}

--- a/test/repository/DeferralReasonRepositoryTests.java
+++ b/test/repository/DeferralReasonRepositoryTests.java
@@ -1,0 +1,74 @@
+package repository;
+
+import static helpers.builders.DeferralReasonBuilder.aDeferralReason;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
+import javax.persistence.NonUniqueResultException;
+import javax.persistence.PersistenceContext;
+
+import model.donordeferral.DeferralReason;
+import model.donordeferral.DeferralReasonType;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import suites.ContextDependentTestSuite;
+
+public class DeferralReasonRepositoryTests extends ContextDependentTestSuite {
+    
+    @PersistenceContext
+    private EntityManager entityManager;
+    @Autowired
+    private DeferralReasonRepository deferralReasonRepository;
+    
+    @Test(expected = NoResultException.class)
+    public void testFindDeferralReasonByTypeWithNoMatchingDeferralReasons_shouldThrow() {
+        deferralReasonRepository.findDeferralReasonByType(DeferralReasonType.AUTOMATED_TTI_UNSAFE);
+    }
+    
+    @Test(expected = NonUniqueResultException.class)
+    public void testFindDeferralReasonByTypeWithMultipleMatchingDeferralReasons_shouldThrow() {
+        DeferralReasonType type = DeferralReasonType.AUTOMATED_TTI_UNSAFE;
+        
+        aDeferralReason()
+                .thatIsNotDeleted()
+                .withType(type)
+                .buildAndPersist(entityManager);
+        aDeferralReason()
+                .thatIsNotDeleted()
+                .withType(type)
+                .buildAndPersist(entityManager);
+        
+        deferralReasonRepository.findDeferralReasonByType(type);
+    }
+    
+    @Test
+    public void testFindDeferralReasonByType_shouldReturnNonDeletedDeferralReasonsMatchingType() {
+        DeferralReasonType type = DeferralReasonType.AUTOMATED_TTI_UNSAFE;
+        
+        // Excluded by deleted flag
+        aDeferralReason()
+                .thatIsDeleted()
+                .withType(type)
+                .buildAndPersist(entityManager);
+
+        // Excluded by type
+        aDeferralReason()
+                .thatIsNotDeleted()
+                .withType(DeferralReasonType.NORMAL)
+                .buildAndPersist(entityManager);
+
+        DeferralReason expectedDeferralReason = aDeferralReason()
+                .thatIsNotDeleted()
+                .withType(type)
+                .buildAndPersist(entityManager);
+
+        DeferralReason returnedDeferralReason = deferralReasonRepository.findDeferralReasonByType(type);
+        
+        assertThat(returnedDeferralReason, is(expectedDeferralReason));
+    }
+
+}

--- a/test/service/ComponentCRUDServiceTests.java
+++ b/test/service/ComponentCRUDServiceTests.java
@@ -1,0 +1,35 @@
+package service;
+
+import static helpers.builders.DonorBuilder.aDonor;
+import static org.mockito.Mockito.verify;
+import model.component.ComponentStatus;
+import model.donor.Donor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import repository.ComponentRepository;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ComponentCRUDServiceTests {
+    
+    @InjectMocks
+    private ComponentCRUDService componentCRUDService;
+    @Mock
+    private ComponentRepository componentRepository;
+    
+    @Test
+    public void testMarkComponentsBelongingToDonorAsUnsafe_shouldDelegateToRepositoryWithCorrectParameters() {
+        
+        Donor donor = aDonor().build();
+        
+        componentCRUDService.markComponentsBelongingToDonorAsUnsafe(donor);
+        
+        verify(componentRepository).updateComponentStatusForDonor(ComponentStatus.AVAILABLE, ComponentStatus.UNSAFE,
+                donor);
+    }
+
+}

--- a/test/service/DonorDeferralCRUDServiceTests.java
+++ b/test/service/DonorDeferralCRUDServiceTests.java
@@ -8,12 +8,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.Date;
+
 import model.donor.Donor;
 import model.donordeferral.DeferralReason;
 import model.donordeferral.DeferralReasonType;
-import model.donordeferral.DeferralType;
 import model.donordeferral.DonorDeferral;
+import model.donordeferral.DurationType;
 
+import org.joda.time.DateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -32,25 +36,62 @@ public class DonorDeferralCRUDServiceTests {
     private DonorDeferralRepository donorDeferralRepository;
     @Mock
     private DeferralReasonRepository deferralReasonRepository;
+    @Mock
+    private DateGeneratorService dateGeneratorService;
     
     @Test
-    public void testCreateAutomatedUnsafeDeferralForDonor_shouldCreateAndPersistDonorDeferral() {
+    public void testCreateDeferralForDonorWithDeferralReasonTypeWithPermanentDeferralReason_shouldCreateAndPersistDonorDeferral() {
         
+        DeferralReasonType irrelevantDeferralReasonType = DeferralReasonType.AUTOMATED_TTI_UNSAFE;
         Donor donor =  aDonor().build();
-        DeferralReason deferralReason = aDeferralReason().build();
+        DeferralReason deferralReason = aDeferralReason()
+                .withType(irrelevantDeferralReasonType)
+                .withDurationType(DurationType.PERMANENT)
+                .build();
         
         DonorDeferral expectedDonorDeferral = aDonorDeferral()
                 .thatIsNotVoided()
                 .withDeferredDonor(donor)
                 .withDeferralReason(deferralReason)
-                .withDeferralType(DeferralType.PERMANENT)
                 .withDeferredUntil(DonorDeferralCRUDService.PERMANENT_DEFERRAL_DATE)
                 .build();
         
-        when(deferralReasonRepository.findDeferralReasonByType(DeferralReasonType.AUTOMATED_TTI_UNSAFE))
+        when(deferralReasonRepository.findDeferralReasonByType(irrelevantDeferralReasonType))
                 .thenReturn(deferralReason);
         
-        DonorDeferral returnedDonorDeferral = donorDeferralCRUDService.createAutomatedUnsafeDeferralForDonor(donor);
+        DonorDeferral returnedDonorDeferral = donorDeferralCRUDService.createDeferralForDonorWithDeferralReasonType(
+                donor, irrelevantDeferralReasonType);
+        
+        verify(donorDeferralRepository).save(argThat(hasSameStateAsDonorDeferral(expectedDonorDeferral)));
+        assertThat(returnedDonorDeferral, hasSameStateAsDonorDeferral(expectedDonorDeferral));
+    }
+    
+    @Test
+    public void testCreateDeferralForDonorWithDeferralReasonTypeWithTemporaryDeferralReason_shouldCreateAndPersistDonorDeferral() {
+        
+        DeferralReasonType irrelevantDeferralReasonType = DeferralReasonType.AUTOMATED_TTI_UNSAFE;
+        int irrelevantDuration = 7;
+        Date now = new Date();
+        Donor donor =  aDonor().build();
+        DeferralReason deferralReason = aDeferralReason()
+                .withType(irrelevantDeferralReasonType)
+                .withDurationType(DurationType.TEMPORARY)
+                .withDefaultDuration(irrelevantDuration)
+                .build();
+        
+        DonorDeferral expectedDonorDeferral = aDonorDeferral()
+                .thatIsNotVoided()
+                .withDeferredDonor(donor)
+                .withDeferralReason(deferralReason)
+                .withDeferredUntil(new DateTime(now).plusDays(irrelevantDuration).toDate())
+                .build();
+        
+        when(deferralReasonRepository.findDeferralReasonByType(irrelevantDeferralReasonType))
+                .thenReturn(deferralReason);
+        when(dateGeneratorService.generateDate()).thenReturn(now);
+        
+        DonorDeferral returnedDonorDeferral = donorDeferralCRUDService.createDeferralForDonorWithDeferralReasonType(
+                donor, irrelevantDeferralReasonType);
         
         verify(donorDeferralRepository).save(argThat(hasSameStateAsDonorDeferral(expectedDonorDeferral)));
         assertThat(returnedDonorDeferral, hasSameStateAsDonorDeferral(expectedDonorDeferral));

--- a/test/service/DonorDeferralCRUDServiceTests.java
+++ b/test/service/DonorDeferralCRUDServiceTests.java
@@ -1,0 +1,59 @@
+package service;
+
+import static helpers.builders.DeferralReasonBuilder.aDeferralReason;
+import static helpers.builders.DonorBuilder.aDonor;
+import static helpers.builders.DonorDeferralBuilder.aDonorDeferral;
+import static helpers.matchers.DonorDeferralMatcher.hasSameStateAsDonorDeferral;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import model.donor.Donor;
+import model.donordeferral.DeferralReason;
+import model.donordeferral.DeferralReasonType;
+import model.donordeferral.DeferralType;
+import model.donordeferral.DonorDeferral;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import repository.DeferralReasonRepository;
+import repository.DonorDeferralRepository;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DonorDeferralCRUDServiceTests {
+    
+    @InjectMocks
+    private DonorDeferralCRUDService donorDeferralCRUDService;
+    @Mock
+    private DonorDeferralRepository donorDeferralRepository;
+    @Mock
+    private DeferralReasonRepository deferralReasonRepository;
+    
+    @Test
+    public void testCreateAutomatedUnsafeDeferralForDonor_shouldCreateAndPersistDonorDeferral() {
+        
+        Donor donor =  aDonor().build();
+        DeferralReason deferralReason = aDeferralReason().build();
+        
+        DonorDeferral expectedDonorDeferral = aDonorDeferral()
+                .thatIsNotVoided()
+                .withDeferredDonor(donor)
+                .withDeferralReason(deferralReason)
+                .withDeferralType(DeferralType.PERMANENT)
+                .withDeferredUntil(DonorDeferralCRUDService.PERMANENT_DEFERRAL_DATE)
+                .build();
+        
+        when(deferralReasonRepository.findDeferralReasonByType(DeferralReasonType.AUTOMATED_TTI_UNSAFE))
+                .thenReturn(deferralReason);
+        
+        DonorDeferral returnedDonorDeferral = donorDeferralCRUDService.createAutomatedUnsafeDeferralForDonor(donor);
+        
+        verify(donorDeferralRepository).save(argThat(hasSameStateAsDonorDeferral(expectedDonorDeferral)));
+        assertThat(returnedDonorDeferral, hasSameStateAsDonorDeferral(expectedDonorDeferral));
+    }
+
+}

--- a/test/service/TestBatchCRUDServiceTests.java
+++ b/test/service/TestBatchCRUDServiceTests.java
@@ -41,6 +41,8 @@ public class TestBatchCRUDServiceTests {
     private PostDonationCounsellingCRUDService postDonationCounsellingCRUDService;
     @Mock
     private DonorDeferralCRUDService donorDeferralCRUDService;
+    @Mock
+    private ComponentCRUDService componentCRUDService;
     
     @Test
     public void testUpdateTestBatchStatusWithStatusChangeNotToClosed_shouldUpdateTestBatchStatus() {
@@ -168,6 +170,8 @@ public class TestBatchCRUDServiceTests {
         verify(testBatchRepository).updateTestBatch(argThat(hasSameStateAsTestBatch(expectedTestBatch)));
         verify(donorDeferralCRUDService).createAutomatedUnsafeDeferralForDonor(donorWithUnsafeDonation);
         verify(donorDeferralCRUDService, never()).createAutomatedUnsafeDeferralForDonor(donorWithSafeDonation);
+        verify(componentCRUDService).markComponentsBelongingToDonorAsUnsafe(donorWithUnsafeDonation);
+        verify(componentCRUDService, never()).markComponentsBelongingToDonorAsUnsafe(donorWithSafeDonation);
         assertThat(returnedTestBatch, hasSameStateAsTestBatch(expectedTestBatch));
     }
 

--- a/test/service/TestBatchCRUDServiceTests.java
+++ b/test/service/TestBatchCRUDServiceTests.java
@@ -19,6 +19,7 @@ import model.bloodtesting.TTIStatus;
 import model.donation.Donation;
 import model.donationbatch.DonationBatch;
 import model.donor.Donor;
+import model.donordeferral.DeferralReasonType;
 import model.testbatch.TestBatch;
 import model.testbatch.TestBatchStatus;
 
@@ -168,8 +169,10 @@ public class TestBatchCRUDServiceTests {
         verify(postDonationCounsellingCRUDService).createPostDonationCounsellingForDonation(unsafeDonation);
         verify(postDonationCounsellingCRUDService, never()).createPostDonationCounsellingForDonation(safeDonation);
         verify(testBatchRepository).updateTestBatch(argThat(hasSameStateAsTestBatch(expectedTestBatch)));
-        verify(donorDeferralCRUDService).createAutomatedUnsafeDeferralForDonor(donorWithUnsafeDonation);
-        verify(donorDeferralCRUDService, never()).createAutomatedUnsafeDeferralForDonor(donorWithSafeDonation);
+        verify(donorDeferralCRUDService).createDeferralForDonorWithDeferralReasonType(donorWithUnsafeDonation,
+                DeferralReasonType.AUTOMATED_TTI_UNSAFE);
+        verify(donorDeferralCRUDService, never()).createDeferralForDonorWithDeferralReasonType(donorWithSafeDonation,
+                DeferralReasonType.AUTOMATED_TTI_UNSAFE);
         verify(componentCRUDService).markComponentsBelongingToDonorAsUnsafe(donorWithUnsafeDonation);
         verify(componentCRUDService, never()).markComponentsBelongingToDonorAsUnsafe(donorWithSafeDonation);
         assertThat(returnedTestBatch, hasSameStateAsTestBatch(expectedTestBatch));

--- a/test/suites/ContextDependentTestSuite.java
+++ b/test/suites/ContextDependentTestSuite.java
@@ -1,0 +1,15 @@
+package suites;
+
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = "file:**/applicationContextTest.xml")
+@WebAppConfiguration
+@Transactional
+public abstract class ContextDependentTestSuite {
+
+}

--- a/test/validator/DeferralReasonBackingFormValidatorTests.java
+++ b/test/validator/DeferralReasonBackingFormValidatorTests.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 
 import model.donordeferral.DeferralReason;
+import model.donordeferral.DurationType;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -39,6 +40,7 @@ public class DeferralReasonBackingFormValidatorTests {
     public void testValidateWithDeferralReasonBackingFormWithDuplicateDeferralReason_shouldHaveErrors() {
         DeferralReason deferralReason = aDeferralReason().build();
         DeferralReasonBackingForm backingForm = aDeferralReasonBackingForm()
+                .withDurationType(DurationType.TEMPORARY)
                 .withDeferralReason(deferralReason)
                 .withDefaultDuration(1)
                 .build();
@@ -55,9 +57,27 @@ public class DeferralReasonBackingFormValidatorTests {
     }
     
     @Test
+    public void testValidateWithDeferralReasonBackingFormWithPermanentDurationTypeAndNoDuration_shouldHaveNoErrors() {
+        DeferralReason deferralReason = aDeferralReason().build();
+        DeferralReasonBackingForm backingForm = aDeferralReasonBackingForm()
+                .withDurationType(DurationType.PERMANENT)
+                .withDeferralReason(deferralReason)
+                .withDefaultDuration(0)
+                .build();
+        
+        when(utilController.isDuplicateDeferralReason(deferralReason)).thenReturn(false);
+
+        Errors errors = new BindException(backingForm, "deferralReasonBackingForm");
+        validator.validate(backingForm, errors);
+        
+        assertThat(errors.getErrorCount(), is(0));
+    }
+    
+    @Test
     public void testValidateWithDeferralReasonBackingFormWithInvalidDefaultDeferralDays_shouldHaveErrors() {
         DeferralReason deferralReason = aDeferralReason().build();
         DeferralReasonBackingForm backingForm = aDeferralReasonBackingForm()
+                .withDurationType(DurationType.TEMPORARY)
                 .withDeferralReason(deferralReason)
                 .withDefaultDuration(0)
                 .build();
@@ -77,6 +97,7 @@ public class DeferralReasonBackingFormValidatorTests {
     public void testValidateWithValidDeferralReasonBackingForm_shouldHaveNoErrors() {
         DeferralReason deferralReason = aDeferralReason().build();
         DeferralReasonBackingForm backingForm = aDeferralReasonBackingForm()
+                .withDurationType(DurationType.TEMPORARY)
                 .withDeferralReason(deferralReason)
                 .withDefaultDuration(1)
                 .build();

--- a/test/validator/DeferralReasonBackingFormValidatorTests.java
+++ b/test/validator/DeferralReasonBackingFormValidatorTests.java
@@ -1,0 +1,92 @@
+package validator;
+
+import static helpers.builders.DeferralReasonBackingFormBuilder.aDeferralReasonBackingForm;
+import static helpers.builders.DeferralReasonBuilder.aDeferralReason;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import model.donordeferral.DeferralReason;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.validation.BindException;
+import org.springframework.validation.Errors;
+import org.springframework.validation.FieldError;
+
+import backingform.DeferralReasonBackingForm;
+import backingform.validator.DeferralReasonBackingFormValidator;
+import controller.UtilController;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeferralReasonBackingFormValidatorTests {
+    
+    private DeferralReasonBackingFormValidator validator;
+    @Mock
+    private UtilController utilController;
+    
+    @Before
+    public void setUpFixture() {
+        validator = new DeferralReasonBackingFormValidator(utilController);
+    }
+    
+    @Test
+    public void testValidateWithDeferralReasonBackingFormWithDuplicateDeferralReason_shouldHaveErrors() {
+        DeferralReason deferralReason = aDeferralReason().build();
+        DeferralReasonBackingForm backingForm = aDeferralReasonBackingForm()
+                .withDeferralReason(deferralReason)
+                .withDefaultDuration(1)
+                .build();
+        
+        when(utilController.isDuplicateDeferralReason(deferralReason)).thenReturn(true);
+
+        Errors errors = new BindException(backingForm, "deferralReasonBackingForm");
+        validator.validate(backingForm, errors);
+        
+        assertThat(errors.getErrorCount(), is(1));
+        List<FieldError> fieldErrors = errors.getFieldErrors("reason");
+        assertThat(fieldErrors.size(), is(1));
+        assertThat(fieldErrors.get(0).getDefaultMessage(), is("Deferral Reason already exists."));
+    }
+    
+    @Test
+    public void testValidateWithDeferralReasonBackingFormWithInvalidDefaultDeferralDays_shouldHaveErrors() {
+        DeferralReason deferralReason = aDeferralReason().build();
+        DeferralReasonBackingForm backingForm = aDeferralReasonBackingForm()
+                .withDeferralReason(deferralReason)
+                .withDefaultDuration(0)
+                .build();
+        
+        when(utilController.isDuplicateDeferralReason(deferralReason)).thenReturn(false);
+
+        Errors errors = new BindException(backingForm, "deferralReasonBackingForm");
+        validator.validate(backingForm, errors);
+        
+        assertThat(errors.getErrorCount(), is(1));
+        List<FieldError> fieldErrors = errors.getFieldErrors("defaultDuration");
+        assertThat(fieldErrors.size(), is(1));
+        assertThat(fieldErrors.get(0).getDefaultMessage(), is("Default duration must be a positive number of days"));
+    }
+    
+    @Test
+    public void testValidateWithValidDeferralReasonBackingForm_shouldHaveNoErrors() {
+        DeferralReason deferralReason = aDeferralReason().build();
+        DeferralReasonBackingForm backingForm = aDeferralReasonBackingForm()
+                .withDeferralReason(deferralReason)
+                .withDefaultDuration(1)
+                .build();
+        
+        when(utilController.isDuplicateDeferralReason(deferralReason)).thenReturn(false);
+
+        Errors errors = new BindException(backingForm, "deferralReasonBackingForm");
+        validator.validate(backingForm, errors);
+        
+        assertThat(errors.getErrorCount(), is(0));
+    }
+
+}


### PR DESCRIPTION
When closing a test batch, create deferrals for donors who have donations with a status of TTI unsafe.

This is related to the default durations for deferral reasons and should only be merged after #344.

Closes #345.