### PR TITLE
Add test batch release stage

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -18,7 +18,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="test">
+	<classpathentry including="**/*.java" kind="src" output="target/test-classes" path="test">
 		<attributes>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
@@ -26,7 +26,7 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
 		<attributes>
-			<attribute name="owner.project.facets" value="java"/>
+			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/pom.xml
+++ b/pom.xml
@@ -410,7 +410,7 @@
 		<dependency>
 		  <groupId>junit</groupId>
 		  <artifactId>junit-dep</artifactId>
-		  <version>4.8.2</version>
+		  <version>4.11</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.mockito</groupId>
@@ -459,7 +459,7 @@
         <dependency>
         	<groupId>org.hamcrest</groupId>
         	<artifactId>hamcrest-all</artifactId>
-        	<version>1.1</version>
+        	<version>1.3</version>
         </dependency>
 	</dependencies>
 </project>

--- a/src/factory/TestBatchViewModelFactory.java
+++ b/src/factory/TestBatchViewModelFactory.java
@@ -1,14 +1,14 @@
 package factory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-
+import java.util.Map;
 import model.donationbatch.DonationBatch;
 import model.testbatch.TestBatch;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
+import service.TestBatchConstraintChecker;
 import viewmodel.DonationBatchViewModel;
 import viewmodel.TestBatchViewModel;
 
@@ -17,8 +17,14 @@ public class TestBatchViewModelFactory {
     
     @Autowired
     private DonationBatchViewModelFactory donationBatchViewModelFactory;
+    @Autowired
+    private TestBatchConstraintChecker testBatchConstraintChecker;
     
     public TestBatchViewModel createTestBatchViewModel(TestBatch testBatch) {
+        return createTestBatchViewModel(testBatch, false);
+    }
+    
+    public TestBatchViewModel createTestBatchViewModel(TestBatch testBatch, boolean isTestingSupervisor) {
         TestBatchViewModel testBatchViewModel = new TestBatchViewModel();
         testBatchViewModel.setId(testBatch.getId());
         testBatchViewModel.setStatus(testBatch.getStatus());
@@ -36,6 +42,11 @@ public class TestBatchViewModelFactory {
             }
         }
         testBatchViewModel.setDonationBatches(donationBatchViewModels);
+        
+        // Set permissions
+        Map<String, Boolean> permissions = new HashMap<>();
+        permissions.put("canRelease", isTestingSupervisor && testBatchConstraintChecker.canReleaseTestBatch(testBatch));
+        testBatchViewModel.setPermissions(permissions);
 
         return testBatchViewModel;
     }

--- a/src/factory/TestBatchViewModelFactory.java
+++ b/src/factory/TestBatchViewModelFactory.java
@@ -19,9 +19,15 @@ public class TestBatchViewModelFactory {
     private DonationBatchViewModelFactory donationBatchViewModelFactory;
     @Autowired
     private TestBatchConstraintChecker testBatchConstraintChecker;
-    
-    public TestBatchViewModel createTestBatchViewModel(TestBatch testBatch) {
-        return createTestBatchViewModel(testBatch, false);
+
+    public List<TestBatchViewModel> createTestBatchViewModels(List<TestBatch> testBatches, boolean isTestingSupervisor) {
+        List<TestBatchViewModel> viewModels = new ArrayList<>();
+        
+        for (TestBatch testBatch : testBatches) {
+            viewModels.add(createTestBatchViewModel(testBatch, isTestingSupervisor));
+        }
+        
+        return viewModels;
     }
     
     public TestBatchViewModel createTestBatchViewModel(TestBatch testBatch, boolean isTestingSupervisor) {

--- a/src/model/testbatch/TestBatchStatus.java
+++ b/src/model/testbatch/TestBatchStatus.java
@@ -1,5 +1,5 @@
 package model.testbatch;
 
 public enum TestBatchStatus {
-	OPEN, READY_TO_CLOSE, CLOSED
+	OPEN, READY_TO_CLOSE, CLOSED, RELEASED;
 }

--- a/src/model/testbatch/TestBatchStatus.java
+++ b/src/model/testbatch/TestBatchStatus.java
@@ -1,5 +1,5 @@
 package model.testbatch;
 
 public enum TestBatchStatus {
-	OPEN, READY_TO_CLOSE, CLOSED, RELEASED;
+	OPEN, RELEASED, CLOSED;
 }

--- a/src/repository/TestBatchRepository.java
+++ b/src/repository/TestBatchRepository.java
@@ -1,32 +1,19 @@
 package repository;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-
-import static java.util.Collections.list;
-
 import java.util.List;
 import java.util.Map;
-
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
-import javax.persistence.Parameter;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
 import javax.persistence.TypedQuery;
-
-import model.donation.Donation;
 import model.donationbatch.DonationBatch;
 import model.testbatch.TestBatch;
 import model.testbatch.TestBatchStatus;
-
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
-
 import factory.TestBatchViewModelFactory;
-import viewmodel.TestBatchViewModel;
 
 @Repository
 @Transactional
@@ -80,7 +67,7 @@ public class TestBatchRepository {
         return em.merge(testBatch);
     }
 
-  public List<TestBatchViewModel> findTestBatches(
+  public List<TestBatch> findTestBatches(
 	      String status, String createdAfterDate,
 	      String createdBeforeDate,Map<String, Object> pagingParams) {
 
@@ -103,14 +90,7 @@ public class TestBatchRepository {
 	    query.setFirstResult(start);
 	    query.setMaxResults(length);
 
-            List<TestBatch> testBatches = query.getResultList();
-            List<TestBatchViewModel> viewModels = new ArrayList<TestBatchViewModel>();
-        for (TestBatch testBatch : testBatches) {
-
-            viewModels.add(testBatchViewModelFactory.createTestBatchViewModel(testBatch));
-        }
-
-        return viewModels;
+        return query.getResultList();
     }
   
   /**

--- a/src/service/TestBatchCRUDService.java
+++ b/src/service/TestBatchCRUDService.java
@@ -46,11 +46,18 @@ public class TestBatchCRUDService {
         LOGGER.info("Updating status of test batch " + testBatchId + " to " + newStatus);
         
         TestBatch testBatch = testBatchRepository.findTestBatchById(testBatchId);
+        
+        if (newStatus == testBatch.getStatus()) {
+            // The status is not being changed so return early
+            return testBatch;
+        }
+
+        if (newStatus == TestBatchStatus.CLOSED && testBatch.getStatus() != TestBatchStatus.RELEASED) {
+            throw new IllegalStateException("Only released test batches can be closed");
+        }
 
         // If the test batch status is changing to released and it has donation batches
-        if (newStatus == TestBatchStatus.RELEASED &&
-                testBatch.getStatus() != TestBatchStatus.RELEASED &&
-                testBatch.getDonationBatches() != null) {
+        if (newStatus == TestBatchStatus.RELEASED && testBatch.getDonationBatches() != null) {
             
             if (!testBatchConstraintChecker.canReleaseTestBatch(testBatch)) {
                 throw new IllegalStateException("Test batch cannot be released");

--- a/src/service/TestBatchCRUDService.java
+++ b/src/service/TestBatchCRUDService.java
@@ -30,6 +30,8 @@ public class TestBatchCRUDService {
     private DonorDeferralStatusCalculator donorDeferralStatusCalculator;
     @Autowired
     private ComponentStatusCalculator componentStatusCalculator;
+    @Autowired
+    private TestBatchConstraintChecker testBatchConstraintChecker;
 
     public void setTestBatchRepository(TestBatchRepository testBatchRepository) {
         this.testBatchRepository = testBatchRepository;
@@ -45,10 +47,14 @@ public class TestBatchCRUDService {
         
         TestBatch testBatch = testBatchRepository.findTestBatchById(testBatchId);
 
-        // If the test batch status is changing to closed and it has donation batches
-        if (newStatus == TestBatchStatus.CLOSED &&
-                testBatch.getStatus() != TestBatchStatus.CLOSED &&
+        // If the test batch status is changing to released and it has donation batches
+        if (newStatus == TestBatchStatus.RELEASED &&
+                testBatch.getStatus() != TestBatchStatus.RELEASED &&
                 testBatch.getDonationBatches() != null) {
+            
+            if (!testBatchConstraintChecker.canReleaseTestBatch(testBatch)) {
+                throw new IllegalStateException("Test batch cannot be released");
+            }
             
             for (DonationBatch donationBatch : testBatch.getDonationBatches()) {
 

--- a/src/service/TestBatchConstraintChecker.java
+++ b/src/service/TestBatchConstraintChecker.java
@@ -1,0 +1,45 @@
+package service;
+
+import model.bloodtesting.BloodTest;
+import model.bloodtesting.BloodTestResult;
+import model.bloodtesting.BloodTestType;
+import model.donation.Donation;
+import model.donationbatch.DonationBatch;
+import model.testbatch.TestBatch;
+import model.testbatch.TestBatchStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TestBatchConstraintChecker {
+
+    public boolean canReleaseTestBatch(TestBatch testBatch) {
+
+        if (testBatch.getStatus() != TestBatchStatus.OPEN) {
+            // Only open test batches can be released
+            return false;
+        }
+
+        // Check for tests with outstanding test outcomes
+        for (DonationBatch donationBatch : testBatch.getDonationBatches()) {
+
+            for (Donation donation : donationBatch.getDonations()) {
+
+                for (BloodTestResult bloodTestResult : donation.getBloodTestResults()) {
+
+                    BloodTest bloodTest = bloodTestResult.getBloodTest();
+
+                    if ((bloodTestResult.getResult() == null || bloodTestResult.getResult().isEmpty()) &&
+                            (bloodTest.getBloodTestType() == BloodTestType.BASIC_BLOODTYPING ||
+                            bloodTest.getBloodTestType() == BloodTestType.BASIC_TTI)) {
+
+                        // This test has an outstanding outcome
+                        return false;
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+}

--- a/src/viewmodel/TestBatchViewModel.java
+++ b/src/viewmodel/TestBatchViewModel.java
@@ -2,10 +2,9 @@ package viewmodel;
 
 import java.util.Date;
 import java.util.List;
-
+import java.util.Map;
 import model.testbatch.TestBatchStatus;
 import utils.DateTimeSerialiser;
-
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 public class TestBatchViewModel {
@@ -17,6 +16,7 @@ public class TestBatchViewModel {
     private String batchNumber;
     private String notes;
     private List<DonationBatchViewModel> donationBatchViewModels;
+    private Map<String, Boolean> permissions;
 
     @JsonSerialize(using = DateTimeSerialiser.class)
     public Date getCreatedDate() {
@@ -86,6 +86,14 @@ public class TestBatchViewModel {
 
     public void setLastUpdated(Date lastUpdatedDate) {
         this.lastUpdatedDate = lastUpdatedDate;
+    }
+
+    public Map<String, Boolean> getPermissions() {
+        return permissions;
+    }
+
+    public void setPermissions(Map<String, Boolean> permissions) {
+        this.permissions = permissions;
     }
 
 }

--- a/test/factory/TestBatchViewModelFactoryTests.java
+++ b/test/factory/TestBatchViewModelFactoryTests.java
@@ -67,7 +67,7 @@ public class TestBatchViewModelFactoryTests extends UnitTestSuite {
         when(donationBatchViewModelFactory.createDonationBatchViewModel(donationBatch, true))
                 .thenReturn(donationBatchViewModel);
         
-        TestBatchViewModel returnedViewModel = testBatchViewModelFactory.createTestBatchViewModel(testBatch);
+        TestBatchViewModel returnedViewModel = testBatchViewModelFactory.createTestBatchViewModel(testBatch, false);
         
         assertThat(returnedViewModel, hasSameStateAsTestBatchViewModel(expectedViewModel));
     }

--- a/test/factory/TestBatchViewModelFactoryTests.java
+++ b/test/factory/TestBatchViewModelFactoryTests.java
@@ -1,0 +1,135 @@
+package factory;
+
+import static helpers.builders.DonationBatchBuilder.aDonationBatch;
+import static helpers.builders.TestBatchBuilder.aTestBatch;
+import static helpers.builders.TestBatchViewModelBuilder.aTestBatchViewModel;
+import static helpers.matchers.TestBatchViewModelMatcher.hasSameStateAsTestBatchViewModel;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import model.donationbatch.DonationBatch;
+import model.testbatch.TestBatch;
+import model.testbatch.TestBatchStatus;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import service.TestBatchConstraintChecker;
+import suites.UnitTestSuite;
+import viewmodel.DonationBatchViewModel;
+import viewmodel.TestBatchViewModel;
+
+public class TestBatchViewModelFactoryTests extends UnitTestSuite {
+
+    private static final Long IRRELEVANT_ID = 4L;
+    private static final TestBatchStatus IRRELEVANT_STATUS = TestBatchStatus.OPEN;
+    private static final String IRRELEVANT_BATCH_NUMBER = "1234";
+    private static final Date IRRELEVANT_CREATED_DATE = new Date();
+    private static final Date IRRELEVANT_LAST_UPDATED_DATE = new Date();
+    private static final String IRRELEVANT_NOTES = "some test batch notes";
+    
+    @InjectMocks
+    private TestBatchViewModelFactory testBatchViewModelFactory;
+    @Mock
+    private DonationBatchViewModelFactory donationBatchViewModelFactory;
+    @Mock
+    private TestBatchConstraintChecker testBatchConstraintChecker;
+    
+    @Test
+    public void testCreateTestBatchViewModelWithDonationBatches_shouldReturnTestBatchViewModelWithTheCorrectState() {
+        
+        DonationBatch donationBatch = aDonationBatch().build();
+        
+        TestBatch testBatch = aTestBatch()
+                .withId(IRRELEVANT_ID)
+                .withStatus(IRRELEVANT_STATUS)
+                .withBatchNumber(IRRELEVANT_BATCH_NUMBER)
+                .withCreatedDate(IRRELEVANT_CREATED_DATE)
+                .withLastUpdatedDate(IRRELEVANT_LAST_UPDATED_DATE)
+                .withDonationBatches(Arrays.asList(donationBatch))
+                .withNotes(IRRELEVANT_NOTES)
+                .build();
+        
+        DonationBatchViewModel donationBatchViewModel = new DonationBatchViewModel();
+        
+        TestBatchViewModel expectedViewModel = aTestBatchViewModel()
+                .withId(IRRELEVANT_ID)
+                .withStatus(IRRELEVANT_STATUS)
+                .withBatchNumber(IRRELEVANT_BATCH_NUMBER)
+                .withCreatedDate(IRRELEVANT_CREATED_DATE)
+                .withLastUpdatedDate(IRRELEVANT_LAST_UPDATED_DATE)
+                .withNotes(IRRELEVANT_NOTES)
+                .withDonationBatches(Arrays.asList(donationBatchViewModel))
+                .withPermission("canRelease", false)
+                .build();
+        
+        when(donationBatchViewModelFactory.createDonationBatchViewModel(donationBatch, true))
+                .thenReturn(donationBatchViewModel);
+        
+        TestBatchViewModel returnedViewModel = testBatchViewModelFactory.createTestBatchViewModel(testBatch);
+        
+        assertThat(returnedViewModel, hasSameStateAsTestBatchViewModel(expectedViewModel));
+    }
+    
+    @Test
+    public void testCreateTestBatchViewModelWithTestingSupervisor_shouldReturnTestBatchViewModelWithTheCorrectState() {
+        
+        TestBatch testBatch = aTestBatch()
+                .withId(IRRELEVANT_ID)
+                .withStatus(IRRELEVANT_STATUS)
+                .withBatchNumber(IRRELEVANT_BATCH_NUMBER)
+                .withCreatedDate(IRRELEVANT_CREATED_DATE)
+                .withLastUpdatedDate(IRRELEVANT_LAST_UPDATED_DATE)
+                .withNotes(IRRELEVANT_NOTES)
+                .build();
+
+        TestBatchViewModel expectedViewModel = aTestBatchViewModel()
+                .withId(IRRELEVANT_ID)
+                .withStatus(IRRELEVANT_STATUS)
+                .withBatchNumber(IRRELEVANT_BATCH_NUMBER)
+                .withCreatedDate(IRRELEVANT_CREATED_DATE)
+                .withLastUpdatedDate(IRRELEVANT_LAST_UPDATED_DATE)
+                .withNotes(IRRELEVANT_NOTES)
+                .withDonationBatches(Collections.<DonationBatchViewModel>emptyList())
+                .withPermission("canRelease", true)
+                .build();
+
+        when(testBatchConstraintChecker.canReleaseTestBatch(testBatch)).thenReturn(true);
+        
+        TestBatchViewModel returnedViewModel = testBatchViewModelFactory.createTestBatchViewModel(testBatch, true);
+        
+        assertThat(returnedViewModel, hasSameStateAsTestBatchViewModel(expectedViewModel));
+    }
+    
+    @Test
+    public void testCreateTestBatchViewModelWithTestingSupervisorAndConstraints_shouldReturnTestBatchViewModelWithTheCorrectState() {
+        
+        TestBatch testBatch = aTestBatch()
+                .withId(IRRELEVANT_ID)
+                .withStatus(IRRELEVANT_STATUS)
+                .withBatchNumber(IRRELEVANT_BATCH_NUMBER)
+                .withCreatedDate(IRRELEVANT_CREATED_DATE)
+                .withLastUpdatedDate(IRRELEVANT_LAST_UPDATED_DATE)
+                .withNotes(IRRELEVANT_NOTES)
+                .build();
+        
+        TestBatchViewModel expectedViewModel = aTestBatchViewModel()
+                .withId(IRRELEVANT_ID)
+                .withStatus(IRRELEVANT_STATUS)
+                .withBatchNumber(IRRELEVANT_BATCH_NUMBER)
+                .withCreatedDate(IRRELEVANT_CREATED_DATE)
+                .withLastUpdatedDate(IRRELEVANT_LAST_UPDATED_DATE)
+                .withNotes(IRRELEVANT_NOTES)
+                .withDonationBatches(Collections.<DonationBatchViewModel>emptyList())
+                .withPermission("canRelease", false)
+                .build();
+
+        when(testBatchConstraintChecker.canReleaseTestBatch(testBatch)).thenReturn(false);
+        
+        TestBatchViewModel returnedViewModel = testBatchViewModelFactory.createTestBatchViewModel(testBatch, true);
+        
+        assertThat(returnedViewModel, hasSameStateAsTestBatchViewModel(expectedViewModel));
+    }
+
+}

--- a/test/helpers/builders/TestBatchBuilder.java
+++ b/test/helpers/builders/TestBatchBuilder.java
@@ -1,7 +1,7 @@
 package helpers.builders;
 
+import java.util.Date;
 import java.util.List;
-
 import model.donationbatch.DonationBatch;
 import model.testbatch.TestBatch;
 import model.testbatch.TestBatchStatus;
@@ -11,6 +11,10 @@ public class TestBatchBuilder extends AbstractEntityBuilder<TestBatch> {
     private Long id;
     private TestBatchStatus status;
     private List<DonationBatch> donationBatches;
+    private String batchNumber;
+    private Date createdDate;
+    private Date lastUpdatedDate;
+    private String notes;
 
     public TestBatchBuilder withId(Long id) {
         this.id = id;
@@ -19,6 +23,26 @@ public class TestBatchBuilder extends AbstractEntityBuilder<TestBatch> {
     
     public TestBatchBuilder withStatus(TestBatchStatus status) {
         this.status = status;
+        return this;
+    }
+    
+    public TestBatchBuilder withBatchNumber(String batchNumber) {
+        this.batchNumber = batchNumber;
+        return this;
+    }
+    
+    public TestBatchBuilder withCreatedDate(Date createdDate) {
+        this.createdDate = createdDate;
+        return this;
+    }
+    
+    public TestBatchBuilder withLastUpdatedDate(Date lastUpdatedDate) {
+        this.lastUpdatedDate = lastUpdatedDate;
+        return this;
+    }
+    
+    public TestBatchBuilder withNotes(String notes) {
+        this.notes = notes;
         return this;
     }
     
@@ -32,6 +56,10 @@ public class TestBatchBuilder extends AbstractEntityBuilder<TestBatch> {
         TestBatch testBatch = new TestBatch();
         testBatch.setId(id);
         testBatch.setStatus(status);
+        testBatch.setBatchNumber(batchNumber);
+        testBatch.setCreatedDate(createdDate);
+        testBatch.setLastUpdated(lastUpdatedDate);
+        testBatch.setNotes(notes);
         testBatch.setDonationBatches(donationBatches);
         return testBatch;
     }

--- a/test/helpers/builders/TestBatchViewModelBuilder.java
+++ b/test/helpers/builders/TestBatchViewModelBuilder.java
@@ -1,0 +1,88 @@
+package helpers.builders;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import model.testbatch.TestBatchStatus;
+import viewmodel.DonationBatchViewModel;
+import viewmodel.TestBatchViewModel;
+
+public class TestBatchViewModelBuilder extends AbstractBuilder<TestBatchViewModel> {
+
+    private Long id;
+    private TestBatchStatus status;
+    private String batchNumber;
+    private Date createdDate;
+    private Date lastUpdatedDate;
+    private String notes;
+    private List<DonationBatchViewModel> donationBatches;
+    private Map<String, Boolean> permissions;
+    
+    public TestBatchViewModelBuilder withId(Long id) {
+        this.id = id;
+        return this;
+    }
+    
+    public TestBatchViewModelBuilder withStatus(TestBatchStatus status) {
+        this.status = status;
+        return this;
+    }
+    
+    public TestBatchViewModelBuilder withBatchNumber(String batchNumber) {
+        this.batchNumber = batchNumber;
+        return this;
+    }
+    
+    public TestBatchViewModelBuilder withCreatedDate(Date createdDate) {
+        this.createdDate = createdDate;
+        return this;
+    }
+    
+    public TestBatchViewModelBuilder withLastUpdatedDate(Date lastUpdatedDate) {
+        this.lastUpdatedDate = lastUpdatedDate;
+        return this;
+    }
+    
+    public TestBatchViewModelBuilder withNotes(String notes) {
+        this.notes = notes;
+        return this;
+    }
+    
+    public TestBatchViewModelBuilder withDonationBatches(List<DonationBatchViewModel> donationBatches) {
+        this.donationBatches = donationBatches;
+        return this;
+    }
+    
+    public TestBatchViewModelBuilder withPermissions(Map<String, Boolean> permissions) {
+        this.permissions = permissions;
+        return this;
+    }
+    
+    public TestBatchViewModelBuilder withPermission(String key, Boolean value) {
+        if (permissions == null) {
+            permissions =  new HashMap<>();
+        }
+        permissions.put(key, value);
+        return this;
+    }
+
+    @Override
+    public TestBatchViewModel build() {
+        TestBatchViewModel testBatchViewModel = new TestBatchViewModel();
+        testBatchViewModel.setId(id);
+        testBatchViewModel.setStatus(status);
+        testBatchViewModel.setBatchNumber(batchNumber);
+        testBatchViewModel.setCreatedDate(createdDate);
+        testBatchViewModel.setLastUpdated(lastUpdatedDate);
+        testBatchViewModel.setNotes(notes);
+        testBatchViewModel.setDonationBatches(donationBatches);
+        testBatchViewModel.setPermissions(permissions);
+        return testBatchViewModel;
+    }
+    
+    public static TestBatchViewModelBuilder aTestBatchViewModel() {
+        return new TestBatchViewModelBuilder();
+    }
+
+}

--- a/test/helpers/matchers/TestBatchViewModelMatcher.java
+++ b/test/helpers/matchers/TestBatchViewModelMatcher.java
@@ -1,0 +1,89 @@
+package helpers.matchers;
+
+import java.util.Objects;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import viewmodel.TestBatchViewModel;
+
+public class TestBatchViewModelMatcher extends TypeSafeMatcher<TestBatchViewModel> {
+    
+    private TestBatchViewModel expected;
+    
+    public TestBatchViewModelMatcher(TestBatchViewModel expected) {
+        this.expected = expected;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("A test batch view model with the following state:")
+                .appendText("\nId: ").appendValue(expected.getId())
+                .appendText("\nStatus: ").appendValue(expected.getStatus())
+                .appendText("\nBatch number: ").appendValue(expected.getBatchNumber())
+                .appendText("\nCreated date: ").appendValue(expected.getCreatedDate())
+                .appendText("\nLast updated date: ").appendValue(expected.getLastUpdated())
+                .appendText("\nNotes: ").appendValue(expected.getNotes())
+                .appendText("\nDonation batches: ").appendValue(expected.getDonationBatches())
+                .appendText("\nPermissions: ").appendValue(expected.getPermissions());
+    }
+
+    @Override
+    protected void describeMismatchSafely(TestBatchViewModel actual, Description description) {
+        
+        if (!Objects.equals(actual.getId(), expected.getId())) {
+            description.appendText("\nId: expected = ").appendValue(expected.getId())
+                    .appendText(", actual = ").appendValue(actual.getId());
+        }
+        
+        if (!Objects.equals(actual.getStatus(), expected.getStatus())) {
+            description.appendText("\nStatus: expected = ").appendValue(expected.getStatus())
+                    .appendText(", actual = ").appendValue(actual.getStatus());
+        }
+        
+        if (!Objects.equals(actual.getBatchNumber(), expected.getBatchNumber())) {
+            description.appendText("\nBatch number: expected = ").appendValue(expected.getBatchNumber())
+                    .appendText(", actual = ").appendValue(actual.getBatchNumber());
+        }
+        
+        if (!Objects.equals(actual.getCreatedDate(), expected.getCreatedDate())) {
+            description.appendText("\nCreated date: expected = ").appendValue(expected.getCreatedDate())
+                    .appendText(", actual = ").appendValue(actual.getCreatedDate());
+        }
+        
+        if (!Objects.equals(actual.getLastUpdated(), expected.getLastUpdated())) {
+            description.appendText("\nLast updated: expected = ").appendValue(expected.getLastUpdated())
+                    .appendText(", actual = ").appendValue(actual.getLastUpdated());
+        }
+        
+        if (!Objects.equals(actual.getNotes(), expected.getNotes())) {
+            description.appendText("\nNotes: expected = ").appendValue(expected.getNotes())
+                    .appendText(", actual = ").appendValue(actual.getNotes());
+        }
+
+        if (!Objects.equals(actual.getDonationBatches(), expected.getDonationBatches())) {
+            description.appendText("\nDonation batches: expected = ").appendValue(expected.getDonationBatches())
+                    .appendText(", actual = ").appendValue(actual.getDonationBatches());
+        }
+
+        if (!Objects.equals(actual.getPermissions(), expected.getPermissions())) {
+            description.appendText("\nPermissions: expected = ").appendValue(expected.getPermissions())
+                    .appendText(", actual = ").appendValue(actual.getPermissions());
+        }
+    }
+
+    @Override
+    public boolean matchesSafely(TestBatchViewModel actual) {
+        return Objects.equals(actual.getId(), expected.getId()) &&
+                Objects.equals(actual.getStatus(), expected.getStatus()) &&
+                Objects.equals(actual.getBatchNumber(), expected.getBatchNumber()) &&
+                Objects.equals(actual.getCreatedDate(), expected.getCreatedDate()) &&
+                Objects.equals(actual.getLastUpdated(), expected.getLastUpdated()) &&
+                Objects.equals(actual.getNotes(), expected.getNotes()) &&
+                Objects.equals(actual.getDonationBatches(), expected.getDonationBatches()) &&
+                Objects.equals(actual.getPermissions(), expected.getPermissions());
+    }
+    
+    public static TestBatchViewModelMatcher hasSameStateAsTestBatchViewModel(TestBatchViewModel expected) {
+        return new TestBatchViewModelMatcher(expected);
+    }
+
+}

--- a/test/repository/TestBatchRepositoryTest.java
+++ b/test/repository/TestBatchRepositoryTest.java
@@ -32,8 +32,6 @@ import org.springframework.test.context.transaction.AfterTransaction;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
-import viewmodel.TestBatchViewModel;
-
 /**
  * Test using DBUnit to test the TestBatchRepository
  */
@@ -113,8 +111,8 @@ public class TestBatchRepositoryTest {
 		String createdAfterDate = "2015-07-10 00:00:00";
 		String createdBeforeDate = "2015-07-11 23:59:59";
 		Map<String, Object> pagingParams = new HashMap<String, Object>();
-		List<TestBatchViewModel> testBatches = testBatchRepository.findTestBatches(status, createdAfterDate,
-		    createdBeforeDate, pagingParams);
+		List<TestBatch> testBatches = testBatchRepository.findTestBatches(status, createdAfterDate, createdBeforeDate,
+		        pagingParams);
 		Assert.assertNotNull("TestBatch not null", testBatches);
 		Assert.assertTrue("TestBatch is empty", testBatches.isEmpty());
 	}
@@ -125,8 +123,8 @@ public class TestBatchRepositoryTest {
 		String createdAfterDate = "2015-08-10 00:00:00";
 		String createdBeforeDate = "2015-08-13 23:59:59";
 		Map<String, Object> pagingParams = new HashMap<String, Object>();
-		List<TestBatchViewModel> testBatches = testBatchRepository.findTestBatches(status, createdAfterDate,
-		    createdBeforeDate, pagingParams);
+		List<TestBatch> testBatches = testBatchRepository.findTestBatches(status, createdAfterDate, createdBeforeDate,
+		        pagingParams);
 		Assert.assertNotNull("TestBatch not null", testBatches);
 		Assert.assertEquals("TestBatch matched on date", 2, testBatches.size());
 	}
@@ -137,8 +135,8 @@ public class TestBatchRepositoryTest {
 		String createdAfterDate = "2015-07-10 00:00:00";
 		String createdBeforeDate = "2015-07-11 23:59:59";
 		Map<String, Object> pagingParams = new HashMap<String, Object>();
-		List<TestBatchViewModel> testBatches = testBatchRepository.findTestBatches(status, createdAfterDate,
-		    createdBeforeDate, pagingParams);
+		List<TestBatch> testBatches = testBatchRepository.findTestBatches(status, createdAfterDate, createdBeforeDate,
+		        pagingParams);
 		Assert.assertNotNull("TestBatch not null", testBatches);
 		Assert.assertEquals("TestBatch matched on date", 1, testBatches.size());
 	}

--- a/test/repository/TestBatchRepositoryTest.java
+++ b/test/repository/TestBatchRepositoryTest.java
@@ -153,10 +153,10 @@ public class TestBatchRepositoryTest {
 	@Test
 	public void testUpdateTestBatch() throws Exception {
 		TestBatch testBatch = testBatchRepository.findTestBatchById(2l);
-		testBatch.setStatus(TestBatchStatus.READY_TO_CLOSE);
+		testBatch.setStatus(TestBatchStatus.RELEASED);
 		testBatchRepository.updateTestBatch(testBatch);
 		TestBatch updatedTestBatch = testBatchRepository.findTestBatchById(2l);
-		Assert.assertEquals("TestBatch status is correct", TestBatchStatus.READY_TO_CLOSE, updatedTestBatch.getStatus());
+		Assert.assertEquals("TestBatch status is correct", TestBatchStatus.RELEASED, updatedTestBatch.getStatus());
 	}
 	
 	@Test

--- a/test/service/TestBatchCRUDServiceTests.java
+++ b/test/service/TestBatchCRUDServiceTests.java
@@ -8,7 +8,9 @@ import static helpers.builders.DonorBuilder.aDonor;
 import static helpers.builders.TestBatchBuilder.aTestBatch;
 import static helpers.matchers.TestBatchMatcher.hasSameStateAsTestBatch;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -46,9 +48,11 @@ public class TestBatchCRUDServiceTests {
     private DonorDeferralStatusCalculator donorDeferralStatusCalculator;
     @Mock
     private ComponentStatusCalculator componentStatusCalculator;
+    @Mock
+    private TestBatchConstraintChecker testBatchConstraintChecker;
     
     @Test
-    public void testUpdateTestBatchStatusWithStatusChangeNotToClosed_shouldUpdateTestBatchStatus() {
+    public void testUpdateTestBatchStatusWithStatusChangeNotToReleased_shouldUpdateTestBatchStatus() {
         long testBatchId = 526;
         TestBatchStatus newStatus = TestBatchStatus.READY_TO_CLOSE;
 
@@ -78,11 +82,11 @@ public class TestBatchCRUDServiceTests {
     @Test
     public void testUpdateTestBatchStatusWithNoStatusChange_shouldUpdateTestBatchStatus() {
         long testBatchId = 526;
-        TestBatchStatus newStatus = TestBatchStatus.CLOSED;
+        TestBatchStatus newStatus = TestBatchStatus.RELEASED;
 
         TestBatch existingTestBatch = aTestBatch()
                 .withId(testBatchId)
-                .withStatus(TestBatchStatus.CLOSED)
+                .withStatus(TestBatchStatus.RELEASED)
                 .build();
 
         TestBatch expectedTestBatch = aTestBatch()
@@ -106,7 +110,7 @@ public class TestBatchCRUDServiceTests {
     @Test
     public void testUpdateTestBatchStatusWithNoDonationBatches_shouldUpdateTestBatchStatus() {
         long testBatchId = 526;
-        TestBatchStatus newStatus = TestBatchStatus.CLOSED;
+        TestBatchStatus newStatus = TestBatchStatus.RELEASED;
 
         TestBatch existingTestBatch = aTestBatch()
                 .withId(testBatchId)
@@ -131,10 +135,37 @@ public class TestBatchCRUDServiceTests {
         assertThat(returnedTestBatch, hasSameStateAsTestBatch(expectedTestBatch));
     }
     
+    @Test(expected = IllegalStateException.class)
+    public void testUpdateTestBatchStatusWithTestBatchWithConstraints_shouldThrow() {
+        long testBatchId = 526;
+
+        List<DonationBatch> donationBatches = Arrays.asList(
+                aDonationBatch()
+                    .withDonations(Arrays.asList(aDonation().withId(22L).withTTIStatus(TTIStatus.TTI_SAFE).build()))
+                    .build()
+        );
+
+        TestBatch existingTestBatch = aTestBatch()
+                .withId(testBatchId)
+                .withStatus(TestBatchStatus.READY_TO_CLOSE)
+                .withDonationBatches(donationBatches)
+                .build();
+
+        when(testBatchRepository.findTestBatchById(testBatchId)).thenReturn(existingTestBatch);
+        when(testBatchConstraintChecker.canReleaseTestBatch(existingTestBatch)).thenReturn(false);
+
+        testBatchCRUDService.updateTestBatchStatus(testBatchId, TestBatchStatus.RELEASED);
+        
+        verify(testBatchRepository, never()).updateTestBatch(any(TestBatch.class));
+        verifyZeroInteractions(postDonationCounsellingCRUDService);
+        verifyZeroInteractions(donorDeferralCRUDService);
+        verifyZeroInteractions(componentCRUDService);
+    }
+    
     @Test
     public void testUpdateTestBatchStatusWithSafeDonation_shouldOnlyUpdateTestBatch() {
         long testBatchId = 526;
-        TestBatchStatus newStatus = TestBatchStatus.CLOSED;
+        TestBatchStatus newStatus = TestBatchStatus.RELEASED;
 
         Donation safeDonation = aDonation()
                 .withId(22L)
@@ -160,6 +191,7 @@ public class TestBatchCRUDServiceTests {
                 .build();
         
         when(testBatchRepository.findTestBatchById(testBatchId)).thenReturn(existingTestBatch);
+        when(testBatchConstraintChecker.canReleaseTestBatch(existingTestBatch)).thenReturn(true);
         when(testBatchRepository.updateTestBatch(argThat(hasSameStateAsTestBatch(expectedTestBatch))))
                 .thenReturn(expectedTestBatch);
 
@@ -175,7 +207,7 @@ public class TestBatchCRUDServiceTests {
     @Test
     public void testUpdateTestBatchStatusWithSafeDonationWithTestsThatDiscardComponents_shouldDiscardComponentsForDonation() {
         long testBatchId = 526;
-        TestBatchStatus newStatus = TestBatchStatus.CLOSED;
+        TestBatchStatus newStatus = TestBatchStatus.RELEASED;
         
         List<BloodTestResult> bloodTestResults = Arrays.asList(aBloodTestResult()
                 .withId(18L)
@@ -207,6 +239,7 @@ public class TestBatchCRUDServiceTests {
                 .build();
         
         when(testBatchRepository.findTestBatchById(testBatchId)).thenReturn(existingTestBatch);
+        when(testBatchConstraintChecker.canReleaseTestBatch(existingTestBatch)).thenReturn(true);
         when(componentStatusCalculator.shouldComponentsBeDiscarded(bloodTestResults)).thenReturn(true);
         when(testBatchRepository.updateTestBatch(argThat(hasSameStateAsTestBatch(expectedTestBatch))))
                 .thenReturn(expectedTestBatch);
@@ -223,7 +256,7 @@ public class TestBatchCRUDServiceTests {
     @Test
     public void testUpdateTestBatchStatusWithUnsafeDonationAndDonorNotToBeDeferred_shouldNotCreateDeferral() {
         long testBatchId = 526;
-        TestBatchStatus newStatus = TestBatchStatus.CLOSED;
+        TestBatchStatus newStatus = TestBatchStatus.RELEASED;
         
         Donor donorWithUnsafeDonation = aDonor().withId(86L).build();
         
@@ -255,6 +288,7 @@ public class TestBatchCRUDServiceTests {
                 .build();
         
         when(testBatchRepository.findTestBatchById(testBatchId)).thenReturn(existingTestBatch);
+        when(testBatchConstraintChecker.canReleaseTestBatch(existingTestBatch)).thenReturn(true);
         when(testBatchRepository.updateTestBatch(argThat(hasSameStateAsTestBatch(expectedTestBatch))))
                 .thenReturn(expectedTestBatch);
         when(donorDeferralStatusCalculator.shouldDonorBeDeferred(bloodTestResults)).thenReturn(false);
@@ -271,7 +305,7 @@ public class TestBatchCRUDServiceTests {
     @Test
     public void testUpdateTestBatchStatusWithUnsafeDonationAndDonorToBeDeferred_shouldCreateDeferralAndCounsellingAndUpdateComponents() {
         long testBatchId = 526;
-        TestBatchStatus newStatus = TestBatchStatus.CLOSED;
+        TestBatchStatus newStatus = TestBatchStatus.RELEASED;
         
         Donor donorWithUnsafeDonation = aDonor().withId(86L).build();
         
@@ -303,6 +337,7 @@ public class TestBatchCRUDServiceTests {
                 .build();
         
         when(testBatchRepository.findTestBatchById(testBatchId)).thenReturn(existingTestBatch);
+        when(testBatchConstraintChecker.canReleaseTestBatch(existingTestBatch)).thenReturn(true);
         when(testBatchRepository.updateTestBatch(argThat(hasSameStateAsTestBatch(expectedTestBatch))))
                 .thenReturn(expectedTestBatch);
         when(donorDeferralStatusCalculator.shouldDonorBeDeferred(bloodTestResults)).thenReturn(true);

--- a/test/service/TestBatchCRUDServiceTests.java
+++ b/test/service/TestBatchCRUDServiceTests.java
@@ -54,7 +54,7 @@ public class TestBatchCRUDServiceTests {
     @Test
     public void testUpdateTestBatchStatusWithStatusChangeNotToReleased_shouldUpdateTestBatchStatus() {
         long testBatchId = 526;
-        TestBatchStatus newStatus = TestBatchStatus.READY_TO_CLOSE;
+        TestBatchStatus newStatus = TestBatchStatus.RELEASED;
 
         TestBatch existingTestBatch = aTestBatch()
                 .withId(testBatchId)
@@ -95,16 +95,34 @@ public class TestBatchCRUDServiceTests {
                 .build();
         
         when(testBatchRepository.findTestBatchById(testBatchId)).thenReturn(existingTestBatch);
-        when(testBatchRepository.updateTestBatch(argThat(hasSameStateAsTestBatch(expectedTestBatch))))
-                .thenReturn(expectedTestBatch);
 
         TestBatch returnedTestBatch = testBatchCRUDService.updateTestBatchStatus(testBatchId, newStatus);
         
-        verify(testBatchRepository).updateTestBatch(argThat(hasSameStateAsTestBatch(expectedTestBatch)));
+        verify(testBatchRepository, never()).updateTestBatch(any(TestBatch.class));
         verifyZeroInteractions(postDonationCounsellingCRUDService);
         verifyZeroInteractions(donorDeferralCRUDService);
         verifyZeroInteractions(componentCRUDService);
         assertThat(returnedTestBatch, hasSameStateAsTestBatch(expectedTestBatch));
+    }
+    
+    @Test(expected = IllegalStateException.class)
+    public void testUpdateTestBatchStatusToClosedWithOpenTestBatch_shouldThrow() {
+        long testBatchId = 526;
+        TestBatchStatus newStatus = TestBatchStatus.CLOSED;
+
+        TestBatch existingTestBatch = aTestBatch()
+                .withId(testBatchId)
+                .withStatus(TestBatchStatus.OPEN)
+                .build();
+        
+        when(testBatchRepository.findTestBatchById(testBatchId)).thenReturn(existingTestBatch);
+
+        testBatchCRUDService.updateTestBatchStatus(testBatchId, newStatus);
+        
+        verify(testBatchRepository, never()).updateTestBatch(any(TestBatch.class));
+        verifyZeroInteractions(postDonationCounsellingCRUDService);
+        verifyZeroInteractions(donorDeferralCRUDService);
+        verifyZeroInteractions(componentCRUDService);
     }
     
     @Test
@@ -114,7 +132,7 @@ public class TestBatchCRUDServiceTests {
 
         TestBatch existingTestBatch = aTestBatch()
                 .withId(testBatchId)
-                .withStatus(TestBatchStatus.READY_TO_CLOSE)
+                .withStatus(TestBatchStatus.OPEN)
                 .build();
 
         TestBatch expectedTestBatch = aTestBatch()
@@ -147,7 +165,7 @@ public class TestBatchCRUDServiceTests {
 
         TestBatch existingTestBatch = aTestBatch()
                 .withId(testBatchId)
-                .withStatus(TestBatchStatus.READY_TO_CLOSE)
+                .withStatus(TestBatchStatus.OPEN)
                 .withDonationBatches(donationBatches)
                 .build();
 
@@ -180,7 +198,7 @@ public class TestBatchCRUDServiceTests {
 
         TestBatch existingTestBatch = aTestBatch()
                 .withId(testBatchId)
-                .withStatus(TestBatchStatus.READY_TO_CLOSE)
+                .withStatus(TestBatchStatus.OPEN)
                 .withDonationBatches(donationBatches)
                 .build();
 
@@ -228,7 +246,7 @@ public class TestBatchCRUDServiceTests {
 
         TestBatch existingTestBatch = aTestBatch()
                 .withId(testBatchId)
-                .withStatus(TestBatchStatus.READY_TO_CLOSE)
+                .withStatus(TestBatchStatus.OPEN)
                 .withDonationBatches(donationBatches)
                 .build();
 
@@ -277,7 +295,7 @@ public class TestBatchCRUDServiceTests {
 
         TestBatch existingTestBatch = aTestBatch()
                 .withId(testBatchId)
-                .withStatus(TestBatchStatus.READY_TO_CLOSE)
+                .withStatus(TestBatchStatus.OPEN)
                 .withDonationBatches(donationBatches)
                 .build();
 
@@ -326,7 +344,7 @@ public class TestBatchCRUDServiceTests {
 
         TestBatch existingTestBatch = aTestBatch()
                 .withId(testBatchId)
-                .withStatus(TestBatchStatus.READY_TO_CLOSE)
+                .withStatus(TestBatchStatus.OPEN)
                 .withDonationBatches(donationBatches)
                 .build();
 

--- a/test/service/TestBatchConstraintCheckerTests.java
+++ b/test/service/TestBatchConstraintCheckerTests.java
@@ -1,0 +1,113 @@
+package service;
+
+import static helpers.builders.BloodTestBuilder.aBloodTest;
+import static helpers.builders.BloodTestResultBuilder.aBloodTestResult;
+import static helpers.builders.DonationBatchBuilder.aDonationBatch;
+import static helpers.builders.DonationBuilder.aDonation;
+import static helpers.builders.TestBatchBuilder.aTestBatch;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import java.util.Arrays;
+import java.util.List;
+import model.bloodtesting.BloodTestResult;
+import model.bloodtesting.BloodTestType;
+import model.donation.Donation;
+import model.testbatch.TestBatch;
+import model.testbatch.TestBatchStatus;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import suites.UnitTestSuite;
+
+public class TestBatchConstraintCheckerTests extends UnitTestSuite {
+    
+    @InjectMocks
+    private TestBatchConstraintChecker testBatchConstraintChecker;
+
+    @Test
+    public void testCanReleaseTestBatchWithNonOpenTestBatch_shouldReturnFalse() {
+        
+        TestBatch testBatch = aTestBatch().withStatus(TestBatchStatus.CLOSED).build();
+        
+        boolean result = testBatchConstraintChecker.canReleaseTestBatch(testBatch);
+        
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void testCanReleaseTestBatchWithNoOutstandingTestResults_shouldReturnTrue() {
+        
+        List<BloodTestResult> bloodTestResults = Arrays.asList(
+                aBloodTestResult()
+                        .withBloodTest(aBloodTest().withBloodTestType(BloodTestType.BASIC_BLOODTYPING).build())
+                        .withResult("POS")
+                        .build(),
+                aBloodTestResult()
+                        .withBloodTest(aBloodTest().withBloodTestType(BloodTestType.BASIC_TTI).build())
+                        .withResult("NEG")
+                        .build(),
+                aBloodTestResult()
+                        .withBloodTest(aBloodTest().withBloodTestType(BloodTestType.CONFIRMATORY_TTI).build())
+                        .withResult(null)
+                        .build(),
+                aBloodTestResult()
+                        .withBloodTest(aBloodTest().withBloodTestType(BloodTestType.ADVANCED_BLOODTYPING).build())
+                        .withResult("")
+                        .build()
+        );
+        
+        List<Donation> donations = Arrays.asList(aDonation().withBloodTestResults(bloodTestResults).build());
+        
+        TestBatch testBatch = aTestBatch()
+                .withStatus(TestBatchStatus.OPEN)
+                .withDonationBatches(Arrays.asList(aDonationBatch().withDonations(donations).build()))
+                .build();
+        
+        boolean result = testBatchConstraintChecker.canReleaseTestBatch(testBatch);
+        
+        assertThat(result, is(true));
+    }
+
+    @Test
+    public void testCanReleaseTestBatchWithOutstandingBloodTypingTestResults_shouldReturnFalse() {
+        
+        List<BloodTestResult> bloodTestResults = Arrays.asList(
+                aBloodTestResult()
+                        .withBloodTest(aBloodTest().withBloodTestType(BloodTestType.BASIC_BLOODTYPING).build())
+                        .withResult(null)
+                        .build()
+        );
+        
+        List<Donation> donations = Arrays.asList(aDonation().withBloodTestResults(bloodTestResults).build());
+        
+        TestBatch testBatch = aTestBatch()
+                .withStatus(TestBatchStatus.OPEN)
+                .withDonationBatches(Arrays.asList(aDonationBatch().withDonations(donations).build()))
+                .build();
+        
+        boolean result = testBatchConstraintChecker.canReleaseTestBatch(testBatch);
+        
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void testCanReleaseTestBatchWithOutstandingTTITestResults_shouldReturnFalse() {
+        
+        List<BloodTestResult> bloodTestResults = Arrays.asList(
+                aBloodTestResult()
+                        .withBloodTest(aBloodTest().withBloodTestType(BloodTestType.BASIC_TTI).build())
+                        .withResult(null)
+                        .build()
+        );
+        
+        List<Donation> donations = Arrays.asList(aDonation().withBloodTestResults(bloodTestResults).build());
+        
+        TestBatch testBatch = aTestBatch()
+                .withStatus(TestBatchStatus.OPEN)
+                .withDonationBatches(Arrays.asList(aDonationBatch().withDonations(donations).build()))
+                .build();
+        
+        boolean result = testBatchConstraintChecker.canReleaseTestBatch(testBatch);
+        
+        assertThat(result, is(false));
+    }
+}


### PR DESCRIPTION
This is the first part of #373.

Changes:
* Adds a RELEASED status to test batches.
* Moves the existing logic for creating deferrals, creating post donation counseling, and flagging components as unsafe to the release stage.
* Adds logic for when a test batch can be closed or released.

To be done in the next part:
* Only allow test batches to be closed when there are no discrepancies.
* Only update donation statuses when the test batch is released.
* Only handle test samples with no discrepancies when releasing a test batch.
* Automatically release individual test samples when discrepancies are resolved and the test batch is released.

@danfuterman Please review.