### PR TITLE
 Check for existence of .git directory before cloning

### DIFF
--- a/infrastructure/deployment/env/provision.sh
+++ b/infrastructure/deployment/env/provision.sh
@@ -23,7 +23,7 @@ sudo apt-get install --quiet --assume-yes \
   tomcat7 \
   maven
 
-if [ -d "/opt/bsis" ]; then
+if [ -d "/opt/bsis/.git" ]; then
   # Checkout the latest version
   cd /opt/bsis
   git fetch


### PR DESCRIPTION
 If the .git directory does not exist then clone the repository,
 otherwise fetch and merge. This handles the case where the repository
 was not successfully cloned the first time the script ran.