### PR TITLE
update provision script

### DIFF
--- a/infrastructure/deployment/env/provision.sh
+++ b/infrastructure/deployment/env/provision.sh
@@ -19,8 +19,11 @@ echo "mysql-server-5.6 mysql-server/root_password_again password ${MYSQL_ROOT_PA
 sudo apt-get install --quiet --assume-yes \
   git \
   mysql-server-5.6 \
+  mysql-server-core-5.6 \
   openjdk-7-jdk \
   tomcat7 \
+  tomcat7-common \
+  libtomcat7-java \
   maven
 
 if [ -d "/opt/bsis" ]; then


### PR DESCRIPTION
Include mysql & tomcat dependencies - 

Ran into the following issues when running the provisioning script on a system that was already set up with MySQL 5.5 and Tomcat 6:

```
The following packages have unmet dependencies:
 mysql-server-5.6 : Depends: mysql-server-core-5.6 (= 5.6.19-0ubuntu0.14.04.1) but it is not going to be installed
 tomcat7 : Depends: tomcat7-common (>= 7.0.52-1ubuntu0.3) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

and 

```
The following packages have unmet dependencies:
 tomcat7-common : Depends: libtomcat7-java (>= 7.0.52-1ubuntu0.3) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

This was resolved by including those package dependencies in the script.