### PR TITLE
Add general config for creating initial components

### DIFF
--- a/liquibase/db-data-lbts.xml
+++ b/liquibase/db-data-lbts.xml
@@ -1137,4 +1137,14 @@
         </insert>
     </changeSet>
 
+    <changeSet id="20151023-1015" author="bausmeier">
+        <insert tableName="GeneralConfig">
+            <column name="name" value="components.createInitialComponents"></column>
+            <column name="value" value="true"></column>
+            <column name="description"
+                value="Enable creation of initial components. Can be disabled in the case where components are not managed by the system."></column>
+            <column name="dataType_id" value="4"></column>
+        </insert>
+    </changeSet>
+
 </databaseChangeLog>

--- a/liquibase/db-data.xml
+++ b/liquibase/db-data.xml
@@ -729,4 +729,14 @@
         </insert>
     </changeSet>
 
+    <changeSet id="20151023-1015" author="bausmeier">
+        <insert tableName="GeneralConfig">
+            <column name="name" value="components.createInitialComponents"></column>
+            <column name="value" value="true"></column>
+            <column name="description"
+                value="Enable creation of initial components. Can be disabled in the case where components are not managed by the system."></column>
+            <column name="dataType_id" value="4"></column>
+        </insert>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/constant/GeneralConfigConstants.java
+++ b/src/constant/GeneralConfigConstants.java
@@ -4,5 +4,6 @@ public class GeneralConfigConstants {
     
     public static final String DONOR_REGISTRATION_OPEN_BATCH_REQUIRED = "donors.registration.openBatchRequired";
     public static final String DEFER_DONORS_WITH_NEG_CONFIRMATORY_OUTCOMES = "testing.deferDonorsWithNegConfirmatoryOutcomes";
+    public static final String CREATE_INITIAL_COMPONENTS = "components.createInitialComponents";
 
 }

--- a/src/repository/DonationRepository.java
+++ b/src/repository/DonationRepository.java
@@ -36,11 +36,13 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import constant.GeneralConfigConstants;
 import repository.bloodtesting.BloodTestingRepository;
 import repository.bloodtesting.BloodTypingMatchStatus;
 import repository.bloodtesting.BloodTypingStatus;
 import repository.events.ApplicationContextProvider;
 import repository.events.DonationUpdatedEvent;
+import service.GeneralConfigAccessorService;
 import valueobject.CollectedDonationValueObject;
 import viewmodel.BloodTestingRuleResult;
 
@@ -65,6 +67,9 @@ public class DonationRepository {
 
   @Autowired
   private ComponentRepository componentRepository;
+  
+  @Autowired
+  private GeneralConfigAccessorService generalConfigAccessorService;
   
   public void saveDonation(Donation donation) {
     em.persist(donation);
@@ -329,14 +334,16 @@ public class DonationRepository {
     
     em.refresh(donation);
    
-    //Create initial component only if the countAsDonation is true
-    if( donation.getPackType().getCountAsDonation() == true)
+    // Create initial component only if the countAsDonation is true and the config option is enabled
+    if (donation.getPackType().getCountAsDonation() &&
+            generalConfigAccessorService.getBooleanValue(GeneralConfigConstants.CREATE_INITIAL_COMPONENTS)) {
         createInitialComponent(donation);
+    }
   
     return donation;
   }
   
-  public void createInitialComponent(Donation donation){
+  private void createInitialComponent(Donation donation){
     
     ComponentType componentType = donation.getPackType().getComponentType();
       

--- a/test/dataset/ComponentRepositoryDataset.xml
+++ b/test/dataset/ComponentRepositoryDataset.xml
@@ -144,4 +144,6 @@
 	<ComponentStatusChange id="1" newStatus="DISCARDED"
 		statusChangeType="DISCARDED" statusChangedOn="2015-08-11 16:13:00.0"
 		changedBy_id="1" component_id="6" statusChangeReason_id="5" />
+	<DataType id="4" dataType="boolean"/>
+    <GeneralConfig id="1" name="components.createInitialComponents" value="true" dataType_id="4" />
 </dataset>

--- a/test/dataset/DonationRepositoryDataset.xml
+++ b/test/dataset/DonationRepositoryDataset.xml
@@ -211,6 +211,7 @@
 		value="30" description="Donation Donor pulseMin" dataType_id="2" />
 	<GeneralConfig id="12" name="donation.donor.pulseMax"
 		value="200" description="Donation Donor pulseMax" dataType_id="2" />
+	<GeneralConfig id="13" name="components.createInitialComponents" value="false" dataType_id="4" />
 		
 	<GenericConfig id="6" propertyName="ageLimitsEnabled"
 		propertyOwner="donationRequirements" propertyValue="true" />


### PR DESCRIPTION
Adds a general config property that can be used to disable the creation
of initial components in the case that the components are not managed by
the system.

Closes #381.