### PR TITLE
Limit status changes

### DIFF
--- a/src/repository/ComponentRepository.java
+++ b/src/repository/ComponentRepository.java
@@ -85,6 +85,11 @@ public class ComponentRepository {
     return updateComponentStatus(component);
   }
 
+    /*
+     * FIXME: This method needs comprehensive tests and the allowed status changes should be documented. It would be
+     * best to write tests for the expected behaviours and check that the method handles those rather than basing the
+     * tests on what is currently implemented.
+     */
   private boolean updateComponentStatus(Component component) {
 
     // if a component has been explicitly discarded maintain that status.
@@ -123,9 +128,12 @@ public class ComponentRepository {
     BloodTypingStatus bloodTypingStatus = c.getBloodTypingStatus();
     TTIStatus ttiStatus = c.getTTIStatus();
 
-    ComponentStatus newComponentStatus = ComponentStatus.QUARANTINED;
+    // Start with the old status if there is one.
+    ComponentStatus newComponentStatus = oldComponentStatus == null ? ComponentStatus.QUARANTINED : oldComponentStatus;
+
     if (bloodTypingStatus.equals(BloodTypingStatus.COMPLETE) &&
-        ttiStatus.equals(TTIStatus.TTI_SAFE)) {
+        ttiStatus.equals(TTIStatus.TTI_SAFE) &&
+        oldComponentStatus != ComponentStatus.UNSAFE) {
       newComponentStatus = ComponentStatus.AVAILABLE;
     }
 


### PR DESCRIPTION
Related to https://github.com/jembi/bsis/issues/383.

> "When you back enter a donation for a deferred donor then the components are discarded correctly, but the donation still gets added to the test batch and if all results are negative then the components can be set to AVAILABLE".

> This was previously identified by Jono, and discussed with Brett, but I misunderstood the impact of this. this should not be possible - if the components were flagged as UNSAFE prior to testing, it should not be possible to update them to AVAILABLE.

Changes:

* Don't change the status to QUARANTINED if it was already set.
* Don't change the status to AVAILABLE if it was UNSAFE.