### PR TITLE
Skip donations without test samples when releasing

### DIFF
--- a/src/service/TestBatchStatusChangeService.java
+++ b/src/service/TestBatchStatusChangeService.java
@@ -54,6 +54,11 @@ public class TestBatchStatusChangeService {
     }
     
     public void handleRelease(Donation donation) {
+      
+        if (!donation.getPackType().getTestSampleProduced()) {
+            LOGGER.debug("Skipping donation without test sample: " + donation);
+            return;
+        }
 
         if (donationConstraintChecker.donationHasDiscrepancies(donation)) {
             LOGGER.info("Skipping donation with discrepancies: " + donation);

--- a/test/service/TestBatchStatusChangeServiceTests.java
+++ b/test/service/TestBatchStatusChangeServiceTests.java
@@ -5,6 +5,7 @@ import static helpers.builders.BloodTestingRuleResultBuilder.aBloodTestingRuleRe
 import static helpers.builders.DonationBatchBuilder.aDonationBatch;
 import static helpers.builders.DonationBuilder.aDonation;
 import static helpers.builders.DonorBuilder.aDonor;
+import static helpers.builders.PackTypeBuilder.aPackType;
 import static helpers.builders.TestBatchBuilder.aTestBatch;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -58,7 +59,7 @@ public class TestBatchStatusChangeServiceTests extends UnitTestSuite {
     @Test
     public void testHandleReleaseWithADonationWithDiscrepancies_shouldDoNothing() {
         
-        Donation donationWithDiscrepancies = aDonation().build();
+        Donation donationWithDiscrepancies = aDonation().withPackType(aPackType().build()).build();
         TestBatch testBatch = aTestBatch()
                 .withDonationBatch(aDonationBatch().withDonation(donationWithDiscrepancies).build())
                 .build();
@@ -71,10 +72,30 @@ public class TestBatchStatusChangeServiceTests extends UnitTestSuite {
     }
     
     @Test
+    public void testHandleReleaseWithDonationWithoutTestSample_shouldDoNothing() {
+        
+        Donation donation = aDonation()
+                .withPackType(aPackType().withTestSampleProduced(false).build())
+                .build();
+        TestBatch testBatch = aTestBatch()
+                .withDonationBatch(aDonationBatch().withDonation(donation).build())
+                .build();
+        
+        when(donationConstraintChecker.donationHasDiscrepancies(donation)).thenReturn(true);
+        
+        testBatchStatusChangeService.handleRelease(testBatch);
+        
+        verifyZeroInteractions(postDonationCounsellingCRUDService, donorDeferralCRUDService, componentCRUDService);
+    }
+    
+    @Test
     public void testHandleReleaseWithoutComponentsToBeDiscarded_shouldUpdateComponentStatuses() {
         
         List<BloodTestResult> bloodTestResults = Arrays.asList(aBloodTestResult().build());
-        Donation donationWithoutDiscrepancies = aDonation().withBloodTestResults(bloodTestResults).build();
+        Donation donationWithoutDiscrepancies = aDonation()
+                .withBloodTestResults(bloodTestResults)
+                .withPackType(aPackType().build())
+                .build();
         TestBatch testBatch = aTestBatch()
                 .withDonationBatch(aDonationBatch().withDonation(donationWithoutDiscrepancies).build())
                 .build();
@@ -96,7 +117,10 @@ public class TestBatchStatusChangeServiceTests extends UnitTestSuite {
     public void testHandleReleaseWithComponentsToBeDiscarded_shouldMarkComponentsAsUnsafe() {
         
         List<BloodTestResult> bloodTestResults = Arrays.asList(aBloodTestResult().build());
-        Donation donationWithoutDiscrepancies = aDonation().withBloodTestResults(bloodTestResults).build();
+        Donation donationWithoutDiscrepancies = aDonation()
+                .withBloodTestResults(bloodTestResults)
+                .withPackType(aPackType().build())
+                .build();
         TestBatch testBatch = aTestBatch()
                 .withDonationBatch(aDonationBatch().withDonation(donationWithoutDiscrepancies).build())
                 .build();
@@ -123,6 +147,7 @@ public class TestBatchStatusChangeServiceTests extends UnitTestSuite {
                 .withTTIStatus(TTIStatus.TTI_UNSAFE)
                 .withDonor(donor)
                 .withBloodTestResults(bloodTestResults)
+                .withPackType(aPackType().build())
                 .build();
         TestBatch testBatch = aTestBatch()
                 .withDonationBatch(aDonationBatch().withDonation(unsafeDonation).build())
@@ -151,6 +176,7 @@ public class TestBatchStatusChangeServiceTests extends UnitTestSuite {
                 .withTTIStatus(TTIStatus.TTI_UNSAFE)
                 .withDonor(donor)
                 .withBloodTestResults(bloodTestResults)
+                .withPackType(aPackType().build())
                 .build();
         TestBatch testBatch = aTestBatch()
                 .withDonationBatch(aDonationBatch().withDonation(unsafeDonation).build())


### PR DESCRIPTION
If a donation does not have a test sample then skip handling it during
the release. Previously this was causing an error to be thrown when
trying to run the blood testing rule engine on the donation.

This addresses issue number 4 of https://github.com/jembi/bsis-frontend/pull/250. Donations without test samples are not shown in the test batch, so should be excluded from the release.