### PR TITLE
Replace age generic configs with general configs

### DIFF
--- a/liquibase/db-changelog.xml
+++ b/liquibase/db-changelog.xml
@@ -1932,5 +1932,26 @@
             <column name="ineligibleDonor" type="tinyint(1)" />
         </addColumn>
     </changeSet>
+    
+    <changeSet id="20151125-1306" author="bausmeier">
+
+        <delete tableName="GenericConfig">
+            <where>propertyName IN ("minimumAge", "maximumAge", "ageLimitsEnabled")</where>
+        </delete>
+        
+        <insert tableName="GeneralConfig">
+			<column name="name" value="donors.minimumAge"></column>
+			<column name="value" value="16"></column>
+			<column name="description" value="The minimum age of a new donor"></column>
+			<column name="dataType_id" value="2"></column>
+        </insert>
+        
+        <insert tableName="GeneralConfig">
+			<column name="name" value="donors.maximumAge"></column>
+			<column name="value" value="65"></column>
+			<column name="description" value="The maximum age of a new donor"></column>
+			<column name="dataType_id" value="2"></column>
+        </insert>
+    </changeSet>
 
 </databaseChangeLog>

--- a/src/backingform/validator/DonorBackingFormValidator.java
+++ b/src/backingform/validator/DonorBackingFormValidator.java
@@ -91,14 +91,6 @@ public class DonorBackingFormValidator implements Validator {
 		  if(utilController.isFutureDate(date)){
 			  errors.rejectValue("donor.birthDate", "date.futureDate", "Cannot be a future date");
 		  }
-		  
-		  else{
-			// Verify Donor's age
-			String errorMessage = utilController.verifyDonorAge(date);
-			if (StringUtils.isNotBlank(errorMessage)){
-				errors.rejectValue("donor.birthDate", "age.outOfRange", errorMessage);
-			}
-		  }
     	}
 	  
     }

--- a/src/constant/GeneralConfigConstants.java
+++ b/src/constant/GeneralConfigConstants.java
@@ -1,9 +1,16 @@
 package constant;
 
 public class GeneralConfigConstants {
-    
-    public static final String DONOR_REGISTRATION_OPEN_BATCH_REQUIRED = "donors.registration.openBatchRequired";
-    public static final String DEFER_DONORS_WITH_NEG_CONFIRMATORY_OUTCOMES = "testing.deferDonorsWithNegConfirmatoryOutcomes";
-    public static final String CREATE_INITIAL_COMPONENTS = "components.createInitialComponents";
+
+  // Donors
+  public static final String DONOR_REGISTRATION_OPEN_BATCH_REQUIRED = "donors.registration.openBatchRequired";
+  public static final String DONOR_MINIMUM_AGE = "donors.minimumAge";
+  public static final String DONOR_MAXIMUM_AGE = "donors.maximumAge";
+  
+  // Testing
+  public static final String DEFER_DONORS_WITH_NEG_CONFIRMATORY_OUTCOMES = "testing.deferDonorsWithNegConfirmatoryOutcomes";
+  
+  // Components
+  public static final String CREATE_INITIAL_COMPONENTS = "components.createInitialComponents";
 
 }

--- a/src/controller/UtilController.java
+++ b/src/controller/UtilController.java
@@ -36,7 +36,6 @@ import org.springframework.beans.NotReadablePropertyException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.Errors;
-import constant.GeneralConfigConstants;
 import repository.DonationRepository;
 import repository.DonationBatchRepository;
 import repository.DonorRepository;
@@ -55,9 +54,7 @@ import repository.PackTypeRepository;
 import repository.DeferralReasonRepository;
 import repository.DiscardReasonRepository;
 import security.BsisUserDetails;
-import service.GeneralConfigAccessorService;
 import repository.DonationTypeRepository;
-import utils.DonorUtils;
 
 @org.springframework.stereotype.Component
 public class UtilController {
@@ -119,9 +116,6 @@ public class UtilController {
 
   @Autowired
   private DonationTypeRepository donationTypeRepository;
-  
-  @Autowired
-  private GeneralConfigAccessorService generalConfigAccessorService;
 
   public Map<String, Map<String, Object>> getFormFieldsForForm(String formName) {
     List<FormField> formFields = formFieldRepository.getFormFields(formName);
@@ -357,23 +351,6 @@ public class UtilController {
 	  else{
 		  return false;
 	  }
-  }
-
-  public String verifyDonorAge(Date birthDate) {
-    Integer donorAge = DonorUtils.computeDonorAge(birthDate);
-
-    if (donorAge == null) {
-      return "One of donor Date of Birth or Age must be specified";
-    }
-
-    int minAge = generalConfigAccessorService.getIntValue(GeneralConfigConstants.DONOR_MINIMUM_AGE);
-    int maxAge = generalConfigAccessorService.getIntValue(GeneralConfigConstants.DONOR_MAXIMUM_AGE);
-
-    if (donorAge < minAge || donorAge > maxAge) {
-      return "Donor age must be between " + minAge + " and " + maxAge + " years.";
-    }
-
-    return null;
   }
 
   public Component findComponent(String donationIdentificationNumber, String componentType) {

--- a/src/controller/UtilController.java
+++ b/src/controller/UtilController.java
@@ -36,6 +36,7 @@ import org.springframework.beans.NotReadablePropertyException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.Errors;
+import constant.GeneralConfigConstants;
 import repository.DonationRepository;
 import repository.DonationBatchRepository;
 import repository.DonorRepository;
@@ -54,6 +55,7 @@ import repository.PackTypeRepository;
 import repository.DeferralReasonRepository;
 import repository.DiscardReasonRepository;
 import security.BsisUserDetails;
+import service.GeneralConfigAccessorService;
 import repository.DonationTypeRepository;
 import utils.DonorUtils;
 
@@ -117,6 +119,9 @@ public class UtilController {
 
   @Autowired
   private DonationTypeRepository donationTypeRepository;
+  
+  @Autowired
+  private GeneralConfigAccessorService generalConfigAccessorService;
 
   public Map<String, Map<String, Object>> getFormFieldsForForm(String formName) {
     List<FormField> formFields = formFieldRepository.getFormFields(formName);
@@ -355,23 +360,20 @@ public class UtilController {
   }
 
   public String verifyDonorAge(Date birthDate) {
-    Map<String, String> config = getConfigProperty("donationRequirements");
-    String errorMessage = "";
-    if (config.get("ageLimitsEnabled").equals("true")) {
-        Integer minAge = Integer.parseInt(config.get("minimumAge"));
-        Integer maxAge = Integer.parseInt(config.get("maximumAge"));
-        Integer donorAge = DonorUtils.computeDonorAge(birthDate);
-        if (donorAge == null) {
-          errorMessage = "One of donor Date of Birth or Age must be specified";
-        }
-        else {
-          if (donorAge < minAge || donorAge > maxAge) {
-            errorMessage = "Donor age must be between " + minAge + " and " + maxAge + " years.";
-          }
-        }
+    Integer donorAge = DonorUtils.computeDonorAge(birthDate);
 
+    if (donorAge == null) {
+      return "One of donor Date of Birth or Age must be specified";
     }
-    return errorMessage;
+
+    int minAge = generalConfigAccessorService.getIntValue(GeneralConfigConstants.DONOR_MINIMUM_AGE);
+    int maxAge = generalConfigAccessorService.getIntValue(GeneralConfigConstants.DONOR_MAXIMUM_AGE);
+
+    if (donorAge < minAge || donorAge > maxAge) {
+      return "Donor age must be between " + minAge + " and " + maxAge + " years.";
+    }
+
+    return null;
   }
 
   public Component findComponent(String donationIdentificationNumber, String componentType) {

--- a/src/service/GeneralConfigAccessorService.java
+++ b/src/service/GeneralConfigAccessorService.java
@@ -20,17 +20,30 @@ public class GeneralConfigAccessorService {
     }
 
     public boolean getBooleanValue(String name) {
+        
+        GeneralConfig generalConfig = getGeneralConfigOfType(name, EnumDataType.BOOLEAN);
+        return Boolean.toString(true).equalsIgnoreCase(generalConfig.getValue());
+    }
+    
+    public int getIntValue(String name) {
+      
+        GeneralConfig generalConfig = getGeneralConfigOfType(name, EnumDataType.INTEGER);
+        return Integer.parseInt(generalConfig.getValue());
+    }
+    
+    private GeneralConfig getGeneralConfigOfType(String name, EnumDataType enumDataType) {
+
         GeneralConfig generalConfig = generalConfigRepository.getGeneralConfigByName(name);
         
         if (generalConfig == null) {
             throw new IllegalArgumentException("General config \"" + name + "\" not found.");
         }
 
-        if (getEnumDataType(generalConfig.getDataType()) != EnumDataType.BOOLEAN) {
-            throw new IllegalArgumentException("General config \"" + name + "\" is not of boolean data type.");
+        if (getEnumDataType(generalConfig.getDataType()) != enumDataType) {
+            throw new IllegalArgumentException("General config \"" + name + "\" is not \"" + enumDataType + "\" type.");
         }
         
-        return Boolean.toString(true).equalsIgnoreCase(generalConfig.getValue());
+        return generalConfig;
     }
     
     private EnumDataType getEnumDataType(DataType dataType) {

--- a/test/service/GeneralConfigAccessorServiceTests.java
+++ b/test/service/GeneralConfigAccessorServiceTests.java
@@ -5,7 +5,6 @@ import static helpers.builders.GeneralConfigBuilder.aGeneralConfig;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -14,20 +13,23 @@ import model.admin.EnumDataType;
 import model.admin.GeneralConfig;
 
 import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 
 import repository.GeneralConfigRepository;
+import suites.UnitTestSuite;
 
-public class GeneralConfigAccessorServiceTests {
+public class GeneralConfigAccessorServiceTests extends UnitTestSuite {
     
     private static final String IRRELEVANT_CONFIG_NAME = "irrelevant.configName";
     
+    @InjectMocks
     private GeneralConfigAccessorService generalConfigAccessorService;
+    @Mock
     private GeneralConfigRepository generalConfigRepository;
     
     @Test(expected = IllegalArgumentException.class)
     public void testGetBooleanValueWithMissingGeneralConfig_shouldThrow() {
-        setUpFixture();
-        
         when(generalConfigRepository.getGeneralConfigByName(IRRELEVANT_CONFIG_NAME)).thenReturn(null);
         
         generalConfigAccessorService.getBooleanValue(IRRELEVANT_CONFIG_NAME);
@@ -35,8 +37,6 @@ public class GeneralConfigAccessorServiceTests {
     
     @Test(expected = IllegalArgumentException.class)
     public void testGetBooleanValueWithNonBooleanGeneralConfig_shouldThrow() {
-        setUpFixture();
-        
         DataType nonBooleanDataType = aDataType().withDataType(EnumDataType.INTEGER.name()).build();
         GeneralConfig generalConfig = aGeneralConfig().withDataType(nonBooleanDataType).build();
         
@@ -56,8 +56,6 @@ public class GeneralConfigAccessorServiceTests {
     }
 
     private void testGetBooleanValue_shouldReturnSameBooleanValue(boolean booleanValue) {
-        setUpFixture();
-        
         DataType booleanDataType = aDataType().withDataType(EnumDataType.BOOLEAN.name()).build();
         GeneralConfig generalConfig = aGeneralConfig()
                 .withDataType(booleanDataType)
@@ -69,16 +67,41 @@ public class GeneralConfigAccessorServiceTests {
         boolean returnedBooleanValue = generalConfigAccessorService.getBooleanValue(IRRELEVANT_CONFIG_NAME);
         
         verify(generalConfigRepository).getGeneralConfigByName(IRRELEVANT_CONFIG_NAME);
-        verifyNoMoreInteractions(generalConfigRepository);
-        
         assertThat(returnedBooleanValue, is(booleanValue));
     }
     
-    private void setUpFixture() {
-        generalConfigRepository = mock(GeneralConfigRepository.class);
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetIntValueWithMissingGeneralConfig_shouldThrow() {
+        when(generalConfigRepository.getGeneralConfigByName(IRRELEVANT_CONFIG_NAME)).thenReturn(null);
         
-        generalConfigAccessorService = new GeneralConfigAccessorService();
-        generalConfigAccessorService.setGeneralConfigRepository(generalConfigRepository);
+        generalConfigAccessorService.getIntValue(IRRELEVANT_CONFIG_NAME);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetIntValueWithNonIntGeneralConfig_shouldThrow() {
+        DataType nonIntDataType = aDataType().withDataType(EnumDataType.BOOLEAN.name()).build();
+        GeneralConfig generalConfig = aGeneralConfig().withDataType(nonIntDataType).build();
+        
+        when(generalConfigRepository.getGeneralConfigByName(IRRELEVANT_CONFIG_NAME)).thenReturn(generalConfig);
+        
+        generalConfigAccessorService.getIntValue(IRRELEVANT_CONFIG_NAME);
+    }
+
+    @Test
+    public void testGetIntValue_shouldReturnCorrectIntValue() {
+        int intValue = 123;
+        DataType booleanDataType = aDataType().withDataType(EnumDataType.INTEGER.name()).build();
+        GeneralConfig generalConfig = aGeneralConfig()
+                .withDataType(booleanDataType)
+                .withValue(Integer.toString(intValue))
+                .build();
+        
+        when(generalConfigRepository.getGeneralConfigByName(anyString())).thenReturn(generalConfig);
+        
+        int returnedIntValue = generalConfigAccessorService.getIntValue(IRRELEVANT_CONFIG_NAME);
+        
+        verify(generalConfigRepository).getGeneralConfigByName(IRRELEVANT_CONFIG_NAME);
+        assertThat(returnedIntValue, is(intValue));
     }
 
 }


### PR DESCRIPTION
This PR moves the age related generic configs to general configs so that they can be used client side.

Relates to https://github.com/jembi/bsis-frontend/issues/253.