### PR TITLE
BSIS-743 Allow any git ref to be specified for provision scripts

### DIFF
--- a/infrastructure/deployment/env/provision.sh
+++ b/infrastructure/deployment/env/provision.sh
@@ -26,10 +26,9 @@ sudo apt-get install --quiet --assume-yes \
 if [ -d "/opt/bsis/.git" ]; then
   # Checkout the latest version
   cd /opt/bsis
-  git fetch
-  git checkout ${1:-master}
-  git merge --ff-only origin/${1:-master}
-else 
+  git fetch origin ${1:-master}
+  git checkout FETCH_HEAD
+else
   # Clone the repository
   sudo mkdir --parents /opt/bsis
   sudo chown --recursive $(whoami):$(groups | awk '{print $1;}') /opt/bsis

--- a/infrastructure/deployment/env/update.sh
+++ b/infrastructure/deployment/env/update.sh
@@ -5,9 +5,8 @@ set -o nounset
 
 # Checkout the latest version
 cd /opt/bsis
-git fetch
-git checkout ${1:-master}
-git merge --ff-only origin/${1:-master}
+git fetch origin ${1:-master}
+git checkout FETCH_HEAD
 
 # Build the war and create the database
 mvn clean install


### PR DESCRIPTION
Fetch the specific reference and check it out instead of fetching all
refs and merging changes into the local version.