### PR TITLE
BSIS-1053 Update Abo/Rh and TTI Reports to use donation venue instead…

### DIFF
--- a/src/repository/DonationNamedQueryConstants.java
+++ b/src/repository/DonationNamedQueryConstants.java
@@ -31,12 +31,12 @@ public class DonationNamedQueryConstants {
   public static final String NAME_FIND_COLLECTED_DONATION_VALUE_OBJECTS_FOR_DATE_RANGE =
       "Donation.findCollectedDonationDtosForDateRange";
   public static final String QUERY_FIND_COLLECTED_DONATION_VALUE_OBJECTS_FOR_DATE_RANGE =
-      "SELECT NEW dto.CollectedDonationDTO(d.donationType, d.donor.gender, d.bloodAbo, d.bloodRh, d.donor.venue, COUNT(d)) " +
-          "FROM Donation d " +
-          "WHERE d.donationDate BETWEEN :startDate AND :endDate " +
+      "SELECT NEW dto.CollectedDonationDTO(d.donationType, do.gender, d.bloodAbo, d.bloodRh, d.venue, COUNT(d)) " +
+          "FROM Donation d, Donor do " +
+          "WHERE d.donor = do AND d.donationDate BETWEEN :startDate AND :endDate " +
           "AND d.isDeleted = :deleted " +
-          "GROUP BY d.donor.venue, d.donor.gender, d.donationType, d.bloodAbo, d.bloodRh " +
-          "ORDER BY d.donor.venue, d.donor.gender, d.donationType, d.bloodAbo, d.bloodRh";
+          "GROUP BY d.venue, do.gender, d.donationType, d.bloodAbo, d.bloodRh " +
+          "ORDER BY d.venue, do.gender, d.donationType, d.bloodAbo, d.bloodRh";
 
   public static final String NAME_FIND_LATEST_DUE_TO_DONATE_DATE_FOR_DONOR =
       "Donation.findLatestDueToDonateDateForDonor";

--- a/test/factory/InventoryFactoryTests.java
+++ b/test/factory/InventoryFactoryTests.java
@@ -97,7 +97,7 @@ public class InventoryFactoryTests {
   public void testExpiryStatusWithFutureExpiryDate_shouldReturnDaysUntilExpiry() {
 
     // Setup
-    DateTime expiresOn = (new DateTime()).plusDays(20);
+    DateTime expiresOn = (new DateTime()).plusHours(99);
     Component component = ComponentBuilder.aComponent()
         .withDonation(DonationBuilder.aDonation().build())
         .withExpiresOn(expiresOn.toDate()).build();
@@ -112,7 +112,7 @@ public class InventoryFactoryTests {
     InventoryViewModel viewModel = inventoryFactory.createViewModel(component);
 
     // Verify
-    Assert.assertEquals("correct expiry status", "19 days to expire", viewModel.getExpiryStatus());
+    Assert.assertEquals("correct expiry status", "4 days to expire", viewModel.getExpiryStatus());
 
   }
   

--- a/test/repository/DonationRepositoryTests.java
+++ b/test/repository/DonationRepositoryTests.java
@@ -55,40 +55,44 @@ public class DonationRepositoryTests extends ContextDependentTestSuite {
     aDonation()
         .thatIsNotDeleted()
         .withDonationDate(irrelevantStartDate)
-        .withDonor(aDonor().withGender(expectedGender).withVenue(expectedVenue).build())
+        .withDonor(aDonor().withGender(expectedGender).build())
         .withDonationType(expectedDonationType)
         .withBloodAbo(expectedBloodAbo)
         .withBloodRh(expectedBloodRh)
+        .withVenue(expectedVenue)
         .buildAndPersist(entityManager);
 
     // Expected
     aDonation()
         .thatIsNotDeleted()
         .withDonationDate(irrelevantEndDate)
-        .withDonor(aDonor().withGender(expectedGender).withVenue(expectedVenue).build())
+        .withDonor(aDonor().withGender(expectedGender).build())
         .withDonationType(expectedDonationType)
         .withBloodAbo(expectedBloodAbo)
         .withBloodRh(expectedBloodRh)
+        .withVenue(expectedVenue)
         .buildAndPersist(entityManager);
 
     // Excluded by date
     aDonation()
         .thatIsNotDeleted()
         .withDonationDate(new Date())
-        .withDonor(aDonor().withGender(expectedGender).withVenue(expectedVenue).build())
+        .withDonor(aDonor().withGender(expectedGender).build())
         .withDonationType(expectedDonationType)
         .withBloodAbo(expectedBloodAbo)
         .withBloodRh(expectedBloodRh)
+        .withVenue(expectedVenue)
         .buildAndPersist(entityManager);
 
     // Excluded by deleted
     aDonation()
         .thatIsDeleted()
         .withDonationDate(irrelevantStartDate)
-        .withDonor(aDonor().withGender(expectedGender).withVenue(expectedVenue).build())
+        .withDonor(aDonor().withGender(expectedGender).build())
         .withDonationType(expectedDonationType)
         .withBloodAbo(expectedBloodAbo)
         .withBloodRh(expectedBloodRh)
+        .withVenue(expectedVenue)
         .buildAndPersist(entityManager);
 
     List<CollectedDonationDTO> expectedDtos = Arrays.asList(


### PR DESCRIPTION
… of donor venue in query

Had to update the from part of the query to "FROM Donation d, Donor do" for JPA to correctly create the sql query to return the donation's venue. If this was not done an error was being thrown (Unknown column 'donation2_.venue_id' in 'on clause').