### PR TITLE
Fix failing test: DataImportServiceTests

### DIFF
--- a/test/bsis/importer/DataImportServiceTests.java
+++ b/test/bsis/importer/DataImportServiceTests.java
@@ -183,6 +183,7 @@ public class DataImportServiceTests extends SecurityContextDependentTestSuite {
     // set up test data (Deferral)
     DeferralReason deferralReason = new DeferralReason();
     deferralReason.setReason("Other reasons");
+    deferralReason.setIsDeleted(false);
     entityManager.persist(deferralReason);
 
     // set up test data (Outcomes)


### PR DESCRIPTION
Relates to BSIS-1049 (https://github.com/jembi/bsis/pull/549)

Fixes failing unit test where DeferralReason cannot be validated because it has a null isDeleted
