### PR TITLE
BSIS-1145: As a laboratory staff user, I want to display an info alert when there are pending TTI or ABO/Rh test outcomes, so that I know when there are pending test outcomes

### DIFF
--- a/src/main/java/org/jembi/bsis/controller/TestResultController.java
+++ b/src/main/java/org/jembi/bsis/controller/TestResultController.java
@@ -156,6 +156,9 @@ public class TestResultController {
     overviewFlags.put("hasReEntryRequiredRepeatBloodTypingTests", false);
     overviewFlags.put("hasReEntryRequiredConfirmatoryTTITests", false);
     overviewFlags.put("hasReEntryRequiredRepeatTTITests", false);
+    overviewFlags.put("hasRepeatBloodTypingTests", false);
+    overviewFlags.put("hasConfirmatoryTTITests", false);
+    overviewFlags.put("hasRepeatTTITests", false);
     overviewFlags.put("hasPendingRepeatTTITests", false);
     overviewFlags.put("hasPendingConfirmatoryTTITests", false);
     overviewFlags.put("hasPendingRepeatBloodTypingTests", false);
@@ -180,21 +183,24 @@ public class TestResultController {
           }
         }
         if (testResult.getBloodTest().getBloodTestType().equals(BloodTestType.REPEAT_TTI)) {
-          overviewFlags.put("hasPendingRepeatTTITests", true);
+          overviewFlags.put("hasRepeatTTITests", true);
         } else if (testResult.getBloodTest().getBloodTestType().equals(BloodTestType.CONFIRMATORY_TTI)) {
-          overviewFlags.put("hasPendingConfirmatoryTTITests", true);
+          overviewFlags.put("hasConfirmatoryTTITests", true);
         } else if (testResult.getBloodTest().getBloodTestType().equals(BloodTestType.REPEAT_BLOODTYPING)) {
-          overviewFlags.put("hasPendingRepeatBloodTypingTests", true);
+          overviewFlags.put("hasRepeatBloodTypingTests", true);
         }
       }
       if (result.getPendingBloodTypingTestsIds().size() > 0) {
         overviewFlags.put("hasPendingRepeatBloodTypingTests", true);
+        overviewFlags.put("hasRepeatBloodTypingTests", true);
       }
       if (result.getPendingConfirmatoryTTITestsIds().size() > 0) {
         overviewFlags.put("hasPendingConfirmatoryTTITests", true);
+        overviewFlags.put("hasConfirmatoryTTITests", true);
       }
       if (result.getPendingRepeatTTITestsIds().size() > 0) {
         overviewFlags.put("hasPendingRepeatTTITests", true);
+        overviewFlags.put("hasRepeatTTITests", true);
       }
       if (result.getBloodTypingMatchStatus().equals(BloodTypingMatchStatus.AMBIGUOUS)) {
         // A confirmation is required to resolve the ambiguous result.


### PR DESCRIPTION
See user story in JIRA: https://jembiprojects.jira.com/browse/BSIS-1145
See front-end PR in Github: https://github.com/jembi/bsis-frontend/pull/550
