### PR TITLE
BSIS-1329: Pending tests are triggered for repeat Donors when only ABO or Rh outcomes are entered

### DIFF
--- a/src/main/java/org/jembi/bsis/service/BloodTestingRuleEngine.java
+++ b/src/main/java/org/jembi/bsis/service/BloodTestingRuleEngine.java
@@ -406,18 +406,16 @@ public class BloodTestingRuleEngine {
    * @param resultSet BloodTestingRuleResultSet that contains the processed test results.
    */
   private void updatePendingAboRhTests(BloodTestingRuleResultSet resultSet) {
-    if (!resultSet.getPendingAboTestsIds().isEmpty() || !resultSet.getPendingRhTestsIds().isEmpty()) {
-      if (resultSet.getBloodTypingMatchStatus() != BloodTypingMatchStatus.NOT_DONE
-          && resultSet.getBloodTypingMatchStatus() != BloodTypingMatchStatus.NO_MATCH) {
-        if (LOGGER.isInfoEnabled()) {
-          LOGGER.info("Donor " + resultSet.getDonation().getDonor().getId()
-              + " is not a first time donor, so pending ABO tests ("
-              + resultSet.getPendingAboTestsIds().size() + ") and pending Rh tests ("
-              + resultSet.getPendingRhTestsIds().size() + ") are not required.");
-        }
-        resultSet.getPendingAboTestsIds().clear();
-        resultSet.getPendingRhTestsIds().clear();
+    if (resultSet.getBloodTypingMatchStatus() == BloodTypingMatchStatus.NO_MATCH) {
+      if (LOGGER.isInfoEnabled()) {
+        LOGGER.info("Donor " + resultSet.getDonation().getDonor().getId()
+            + " is a first time donor, so pending ABO tests ("
+            + resultSet.getPendingAboTestsIds().size() + ") and pending Rh tests ("
+            + resultSet.getPendingRhTestsIds().size() + ") are required.");
       }
+    } else {
+      resultSet.getPendingAboTestsIds().clear();
+      resultSet.getPendingRhTestsIds().clear();
     }
   }
 

--- a/src/test/java/org/jembi/bsis/helpers/matchers/BloodTestingRuleResultSetMatcher.java
+++ b/src/test/java/org/jembi/bsis/helpers/matchers/BloodTestingRuleResultSetMatcher.java
@@ -19,7 +19,9 @@ public class BloodTestingRuleResultSetMatcher extends TypeSafeMatcher<BloodTesti
     description.appendText("A BloodTestingRuleResultSet with the following state:")
         .appendText("\nTtiStatus: ").appendValue(expected.getTtiStatus())
         .appendText("\nBloodTypingStatus: ").appendValue(expected.getBloodTypingStatus())
-        .appendText("\nBloodTypingMatchStatus: ").appendValue(expected.getBloodTypingMatchStatus());
+        .appendText("\nBloodTypingMatchStatus: ").appendValue(expected.getBloodTypingMatchStatus())
+        .appendText("\nPendingAboTestsIds: ").appendValue(expected.getPendingAboTestsIds())
+        .appendText("\nPendingRhTestsIds: ").appendValue(expected.getPendingRhTestsIds());
     
     if (!expected.getBloodAboChanges().isEmpty()) {
       description.appendText("\nABO: ").appendValue(expected.getBloodAboChanges().iterator().next());
@@ -28,6 +30,7 @@ public class BloodTestingRuleResultSetMatcher extends TypeSafeMatcher<BloodTesti
     if (!expected.getBloodRhChanges().isEmpty()) {
       description.appendText("\nRh: ").appendValue(expected.getBloodRhChanges().iterator().next());
     }
+
   }
 
   @Override
@@ -41,6 +44,8 @@ public class BloodTestingRuleResultSetMatcher extends TypeSafeMatcher<BloodTesti
     return Objects.equals(actual.getTtiStatus(), expected.getTtiStatus())
         && Objects.equals(actual.getBloodTypingStatus(), expected.getBloodTypingStatus())
         && Objects.equals(actual.getBloodTypingMatchStatus(), expected.getBloodTypingMatchStatus())
+        && Objects.equals(actual.getPendingAboTestsIds(), expected.getPendingAboTestsIds())
+        && Objects.equals(actual.getPendingRhTestsIds(), expected.getPendingRhTestsIds())
         && Objects.equals(actualAbo, expectedAbo)
         && Objects.equals(actualRh, expectedRh);
   }

--- a/src/test/java/org/jembi/bsis/repository/bloodtesting/BloodTestingRuleEngineTest.java
+++ b/src/test/java/org/jembi/bsis/repository/bloodtesting/BloodTestingRuleEngineTest.java
@@ -189,7 +189,7 @@ public class BloodTestingRuleEngineTest extends ContextDependentTestSuite {
     Assert.assertEquals("bloodAb has a result", 1, result.getBloodAbo().length());
     Assert.assertEquals("bloodRh is empty", 0, result.getBloodRh().length());
     Assert.assertEquals("No pending TTI tests", 0, result.getPendingRepeatAndConfirmatoryTtiTestsIds().size());
-    Assert.assertEquals("No pending blood typing tests", 1, result.getPendingBloodTypingTestsIds().size());
+    Assert.assertEquals("No pending blood typing tests", 0, result.getPendingBloodTypingTestsIds().size());
     Assert.assertEquals("1 available test result(s)", 1, result.getAvailableTestResults().size());
     Assert.assertFalse("No ABO Uninterpretable", result.getAboUninterpretable());
     Assert.assertFalse("No RH Uninterpretable", result.getRhUninterpretable());


### PR DESCRIPTION
Updated the logic in the BloodTestingRulesEngine so that ABO and Rh tests
are cleared by default and not cleared when the donor is a first time
donor and both ABO and Rh and have been captured.

This fixes an issue where pending ABO/Rh tests were triggered for
a repeat donor, if only ABO or Rh outcomes were entered.