### PR TITLE
BSIS-2118 Add @JsonIgnore to ComponentBackingForm for hasComponentBatch

### DIFF
--- a/src/main/java/org/jembi/bsis/backingform/ComponentBackingForm.java
+++ b/src/main/java/org/jembi/bsis/backingform/ComponentBackingForm.java
@@ -144,4 +144,9 @@ public class ComponentBackingForm {
     // Ignore
   }
 
+  @JsonIgnore
+  public void setHasComponentBatch(boolean hasComponentBatch) {
+    // Ignore
+  }
+
 }


### PR DESCRIPTION
Previously a hasComponentBatch boolean was added to the view model. This caused
the controller to fail once the component was sent up to the server with
the unexpected field. This commit adds a JsonIgnore to ignore this field