### PR TITLE
BSIS-2116 As an implementer, I need BSIS distributables to be included on Github release pages, so that I can implement BSIS without compiling the application

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ sudo: false
 
 deploy:
   provider: releases
-  api_key: "47a92f9761a055720a1b35ec021db098d6a2e2d1"
+  api_key: 
+    secure: "obWrELIxkp/UCaKub2ZUt2Na84gvvtpJlE5DFLGYUYv1Wy2IHmp/Jd/b2fgPXre+t7gMlGVnM6Fh44C6rUxhpE4ALgsnWUYfyAKXPTgbfUWCFWGRd9wtBAMQzqyUKow+Y+Ssnvks0KvJWusX0igp5VtB4f5qMr1uc9J04iZdaESzmUIXQ/69UrQRPtgm7O3mJnvOHYWmE/S8N5iPd9nhz0dv0WWKiHYRhTP+6etbijS3poXLd2z9ympx+Zoi+kompv6qxRW11Z7g/RTHsFQ7nHnp404ABfuqKPG7ruBEe5zYPY/lX7tZALJdzR1InEXBP20EBaigahpqFYfMq90Ie3qP5UsoRKvv2cj/CatUm93nvt5KuM7+ui7zOom+lANvKxwF2A2k4R6zLehaSjI90VUSR4Xh6zygCO5WvVn/tdxRFM9MDqrVjOYea60gFZECeRQP0EO2aj8LsCGpUk4V5Hsy3vMBrhTXf8I4CfHCbB2+dHbqloZuczrw+PJAs7n1nBZCPMAzU8P/VV4Q8CH8vdVwiHJkWv1tAtkfQOU8eeh5tskxPgpKYldCanT8W3y9DZhTIYFO+VuIix2LpcwRJZkw5r1dM7kOZa6yrkFmQ2Z+vTeDYEYQ0/M+BQJIyD+kTzM5CqWomBCPuCJuP+v4+zyd5joI/+DSGjwuxskFF/I="
   file: "target/bsis.war"
   skip_cleanup: true
   on:


### PR DESCRIPTION
https://jembiprojects.jira.com/browse/BSIS-2116