### PR TITLE
BSIS-2868 Allow transfusion creation on same date of component

### DIFF
--- a/src/main/java/org/jembi/bsis/backingform/validator/TransfusionBackingFormValidator.java
+++ b/src/main/java/org/jembi/bsis/backingform/validator/TransfusionBackingFormValidator.java
@@ -1,6 +1,5 @@
 package org.jembi.bsis.backingform.validator;
 
-import java.util.Date;
 import java.util.List;
 
 import javax.persistence.NoResultException;
@@ -19,6 +18,8 @@ import org.jembi.bsis.repository.ComponentTypeRepository;
 import org.jembi.bsis.repository.DonationRepository;
 import org.jembi.bsis.repository.LocationRepository;
 import org.jembi.bsis.repository.TransfusionRepository;
+import org.jembi.bsis.service.DateGeneratorService;
+import org.joda.time.LocalDate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.Errors;
 
@@ -39,6 +40,9 @@ public class TransfusionBackingFormValidator extends BaseValidator<TransfusionBa
 
   @Autowired
   private TransfusionRepository transfusionRepository;
+
+  @Autowired
+  private DateGeneratorService dateGeneratorService;
 
   @Override
   public void validateForm(TransfusionBackingForm form, Errors errors) {
@@ -169,15 +173,19 @@ public class TransfusionBackingFormValidator extends BaseValidator<TransfusionBa
   }
 
   private void validateDateTransfused(TransfusionBackingForm form, Errors errors, Component component) {
-    Date transfusionDate = form.getDateTransfused();
+    LocalDate transfusionDate = dateGeneratorService.generateLocalDate(form.getDateTransfused());
     if (transfusionDate == null) {
       errors.rejectValue("dateTransfused", "errors.required", "dateTransfused is required");
     } else {
-      if (new Date().before(transfusionDate)) {
+      LocalDate currentDate = dateGeneratorService.generateLocalDate();
+      if (currentDate.isBefore(transfusionDate)) {
         errors.rejectValue("dateTransfused", "errors.invalid", "dateTransfused must be in the past");
-      } else if (component != null && transfusionDate.before(component.getCreatedOn())) {
-        errors.rejectValue("dateTransfused", "errors.invalid.dateTransfusedAfterComponentCreated",
+      } else if (component != null) {
+        LocalDate createdOnDate = dateGeneratorService.generateLocalDate(component.getCreatedOn());
+        if (transfusionDate.isBefore(createdOnDate)) {
+          errors.rejectValue("dateTransfused", "errors.invalid.dateTransfusedAfterComponentCreated",
             "dateTransfused must be after the date that the component was created on");
+        }
       }
     }
   }

--- a/src/main/java/org/jembi/bsis/service/DateGeneratorService.java
+++ b/src/main/java/org/jembi/bsis/service/DateGeneratorService.java
@@ -3,6 +3,7 @@ package org.jembi.bsis.service;
 import java.util.Calendar;
 import java.util.Date;
 
+import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.springframework.stereotype.Service;
 
@@ -42,5 +43,28 @@ public class DateGeneratorService {
    */
   public Date generateDate(Date date) {
     return new LocalDate(date).toDate();
+  }
+
+  /**
+   * Converts a java.util.Date to a LocalDate (Joda) 
+   * @param date
+   * @return
+   */
+  public LocalDate generateLocalDate(Date date) {
+    if (date == null) {
+      return null;
+    }
+    DateTime dt = new DateTime(date);
+    return dt.toLocalDate();
+  }
+
+  /**
+   * Returns new LocalDate with current date
+   * 
+   * @param date
+   * @return
+   */
+  public LocalDate generateLocalDate() {
+    return new LocalDate();
   }
 }

--- a/src/test/java/org/jembi/bsis/backingform/validator/TransfusionBackingFormValidatorTests.java
+++ b/src/test/java/org/jembi/bsis/backingform/validator/TransfusionBackingFormValidatorTests.java
@@ -38,8 +38,10 @@ import org.jembi.bsis.repository.ComponentTypeRepository;
 import org.jembi.bsis.repository.DonationRepository;
 import org.jembi.bsis.repository.LocationRepository;
 import org.jembi.bsis.repository.TransfusionRepository;
+import org.jembi.bsis.service.DateGeneratorService;
 import org.jembi.bsis.suites.UnitTestSuite;
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -68,6 +70,26 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
 
   @Mock
   private TransfusionRepository transfusionRepository;
+
+  @Mock
+  private DateGeneratorService dateGeneratorService;
+
+  private void setupDateGeneratorServiceMocks(Date transfusedDate, Date componentCreatedOnDate, boolean includeComponentCreatedOnMock) {
+    when(dateGeneratorService.generateLocalDate(transfusedDate)).thenReturn(new LocalDate(transfusedDate));
+    when(dateGeneratorService.generateLocalDate()).thenReturn(new LocalDate(new Date()));
+    if (includeComponentCreatedOnMock) {
+      when(dateGeneratorService.generateLocalDate(componentCreatedOnDate))
+        .thenReturn(new LocalDate(componentCreatedOnDate));
+    }
+  }
+
+  private void setupDateGeneratorServiceMocks(Date transfusedDate, Date componentCreatedOnDate) {
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate, true);
+  }
+
+  private void setupDateGeneratorServiceMocks(Date transfusedDate) {
+    setupDateGeneratorServiceMocks(transfusedDate, null, false);
+  }
 
   @Test
   public void testValidateValidTransfusionFormWithDINAndComponentCode_shouldntGetErrors() {
@@ -111,6 +133,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenReturn(donation);
     when(componentRepository.findComponentByCodeAndDIN(componentCode, din)).thenReturn(component);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -177,6 +200,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(componentRepository.findComponentByCodeAndDIN(componentCode, din)).thenReturn(component);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
     when(transfusionRepository.findTransfusionById(transfusionId)).thenReturn(existingTransfusion);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -249,6 +273,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(componentRepository.findComponentsByDINAndType(din, componentTypeId)).thenReturn(components);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
     when(transfusionRepository.findTransfusionById(transfusionId)).thenReturn(existingTransfusion);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -322,6 +347,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(componentRepository.findComponentsByDINAndType(din, componentTypeId)).thenReturn(components);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
     when(transfusionRepository.findTransfusionById(transfusionId)).thenReturn(existingTransfusion);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -377,6 +403,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(componentTypeRepository.verifyComponentTypeExists(componentTypeId)).thenReturn(true);
     when(componentRepository.findComponentsByDINAndType(din, componentTypeId)).thenReturn(components);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -434,6 +461,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(componentRepository.findComponentByCodeAndDIN(componentCode, din)).thenReturn(components.get(0));
     when(componentRepository.findComponentsByDINAndType(din, componentTypeId)).thenReturn(components);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -470,6 +498,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
 
     when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenThrow(NoResultException.class);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -504,6 +533,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     Errors errors = new MapBindingResult(new HashMap<String, String>(), "transfusion");
 
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -548,6 +578,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(componentTypeRepository.verifyComponentTypeExists(componentTypeId)).thenReturn(false);
     when(componentRepository.findComponentsByDINAndType(din, componentTypeId)).thenReturn(components);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -592,6 +623,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(componentTypeRepository.verifyComponentTypeExists(componentTypeId)).thenReturn(true);
     when(componentRepository.findComponentsByDINAndType(din, componentTypeId)).thenReturn(components);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -653,6 +685,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(componentTypeRepository.verifyComponentTypeExists(componentTypeId)).thenReturn(true);
     when(componentRepository.findComponentsByDINAndType(din, componentTypeId)).thenReturn(components);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -693,6 +726,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
 
     when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenReturn(donation);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -735,6 +769,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
 
     when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenReturn(donation);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -778,6 +813,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenReturn(donation);
     when(componentRepository.findComponentByCodeAndDIN(componentCode, din)).thenThrow(NoResultException.class);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -840,6 +876,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
         .build());
     when(componentRepository.findComponentsByDINAndType(din, 1L)).thenReturn(components);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -891,6 +928,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenReturn(donation);
     when(componentRepository.findComponentByCodeAndDIN(componentCode, din)).thenReturn(component);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -945,6 +983,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(componentTypeRepository.verifyComponentTypeExists(componentTypeId)).thenReturn(true);
     when(componentRepository.findComponentsByDINAndType(din, componentTypeId)).thenReturn(components);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -995,6 +1034,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenReturn(donation);
     when(componentRepository.findComponentByCodeAndDIN(componentCode, din)).thenReturn(component);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -1047,6 +1087,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenReturn(donation);
     when(componentRepository.findComponentByCodeAndDIN(componentCode, din)).thenReturn(component);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -1099,6 +1140,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenReturn(donation);
     when(componentRepository.findComponentByCodeAndDIN(componentCode, din)).thenReturn(component);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -1151,6 +1193,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenReturn(donation);
     when(componentRepository.findComponentByCodeAndDIN(componentCode, din)).thenReturn(component);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -1251,6 +1294,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenReturn(donation);
     when(componentRepository.findComponentByCodeAndDIN(componentCode, din)).thenReturn(component);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -1258,6 +1302,94 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     // Verify
     assertThat(errors.getErrorCount(), is(1));
     assertThat(errors.getFieldError("dateTransfused").getCode(), is("errors.invalid"));
+  }
+  
+  @Test
+  public void testValidateTransfusionFormWithValidTransfusionDateOnSameDateAsComponentCreatedOnDate_shouldGetNoErrors() {
+    // Set up data
+    Date transfusedDate = (new DateTime()).minusDays(2).toDate();
+    String din = "12345";
+    String componentCode = "1234";
+
+    Date componentCreatedOnDate = (new DateTime()).minusDays(2).toDate();
+
+    Component component = aComponent().withId(1L).withComponentCode(componentCode).withStatus(ComponentStatus.ISSUED)
+        .withCreatedOn(componentCreatedOnDate).build();
+
+    Donation donation = aDonation().withDonationIdentificationNumber(din).withComponent(component).build();
+
+    long usageSiteId = 1L;
+    Location aUsageSiteLocation = aUsageSite().withId(usageSiteId).build();
+    LocationBackingForm aUsageSite = aUsageSiteBackingForm().withId(usageSiteId).build();
+
+    TransfusionBackingForm form = aTransfusionBackingForm().withDonationIdentificationNumber(din)
+        .withComponentCode(componentCode).withReceivedFrom(aUsageSite).withDateTransfused(transfusedDate)
+        .withTransfusionOutcome(TransfusionOutcome.TRANSFUSED_UNEVENTFULLY)
+        .withPatient(aPatientBackingForm().withName1("name1").withName2("name2").build()).build();
+
+    Errors errors = new MapBindingResult(new HashMap<String, String>(), "transfusion");
+
+    when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenReturn(donation);
+    when(componentRepository.findComponentByCodeAndDIN(componentCode, din)).thenReturn(component);
+    when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
+
+    // Run test
+    validator.validateForm(form, errors);
+
+    // Verify
+    assertThat(errors.getErrorCount(), is(0));
+  }
+
+  @Test
+  public void testValidateTransfusionFormWithValidTransfusionDateOnSameDateAsComponentCreatedOnDateOnCurrentDate_shouldGetNoErrors() {
+    // Set up data
+    Date transfusedDate = new Date();
+    String din = "12345";
+    String componentCode = "1234";
+
+    Date componentCreatedOnDate = new Date();
+    
+    Component component = aComponent()
+        .withId(1L)
+        .withComponentCode(componentCode)
+        .withStatus(ComponentStatus.ISSUED)
+        .withCreatedOn(componentCreatedOnDate)
+        .build();
+
+    Donation donation = aDonation()
+        .withDonationIdentificationNumber(din)
+        .withComponent(component)
+        .build();
+
+    long usageSiteId = 1L;
+    Location aUsageSiteLocation = aUsageSite().withId(usageSiteId).build();
+    LocationBackingForm aUsageSite = aUsageSiteBackingForm().withId(usageSiteId).build();
+
+    TransfusionBackingForm form = aTransfusionBackingForm()
+        .withDonationIdentificationNumber(din)
+        .withComponentCode(componentCode)
+        .withReceivedFrom(aUsageSite)
+        .withDateTransfused(transfusedDate)
+        .withTransfusionOutcome(TransfusionOutcome.TRANSFUSED_UNEVENTFULLY)
+        .withPatient(aPatientBackingForm()
+            .withName1("name1")
+            .withName2("name2")
+            .build())
+        .build();
+
+    Errors errors = new MapBindingResult(new HashMap<String, String>(), "transfusion");
+
+    when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenReturn(donation);
+    when(componentRepository.findComponentByCodeAndDIN(componentCode, din)).thenReturn(component);
+    when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
+
+    // Run test
+    validator.validateForm(form, errors);
+
+    // Verify
+    assertThat(errors.getErrorCount(), is(0));
   }
 
   @Test
@@ -1302,6 +1434,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenReturn(donation);
     when(componentRepository.findComponentByCodeAndDIN(componentCode, din)).thenReturn(component);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -1347,6 +1480,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
 
     when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenReturn(donation);
     when(componentRepository.findComponentByCodeAndDIN(componentCode, din)).thenReturn(component);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -1398,6 +1532,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenReturn(donation);
     when(componentRepository.findComponentByCodeAndDIN(componentCode, din)).thenReturn(component);
     when(locationRepository.getLocation(aProcessingSiteId)).thenReturn(aProcessingSite);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -1449,6 +1584,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenReturn(donation);
     when(componentRepository.findComponentByCodeAndDIN(componentCode, din)).thenReturn(component);
     when(locationRepository.getLocation(usageSiteId)).thenThrow(NoResultException.class);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -1496,6 +1632,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenReturn(donation);
     when(componentRepository.findComponentByCodeAndDIN(componentCode, din)).thenReturn(component);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -1545,6 +1682,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenReturn(donation);
     when(componentRepository.findComponentByCodeAndDIN(componentCode, din)).thenReturn(component);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);
@@ -1598,6 +1736,7 @@ public class TransfusionBackingFormValidatorTests extends UnitTestSuite {
     when(donationRepository.findDonationByDonationIdentificationNumber(din)).thenReturn(donation);
     when(componentRepository.findComponentByCodeAndDIN(componentCode, din)).thenReturn(component);
     when(locationRepository.getLocation(usageSiteId)).thenReturn(aUsageSiteLocation);
+    setupDateGeneratorServiceMocks(transfusedDate, componentCreatedOnDate);
 
     // Run test
     validator.validateForm(form, errors);

--- a/src/test/java/org/jembi/bsis/service/DateGeneratorServiceTests.java
+++ b/src/test/java/org/jembi/bsis/service/DateGeneratorServiceTests.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertEquals;
 import java.util.Calendar;
 import java.util.Date;
 
+import org.joda.time.LocalDate;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -32,5 +34,18 @@ public class DateGeneratorServiceTests {
 
     assertEquals(aDate, expectedDate);
 
+  }
+
+  @Test
+  public void testgenerateLocalDateWithNullDate_shouldReturnNull() throws Exception {
+    LocalDate date = service.generateLocalDate(null);
+    Assert.assertNull(date);
+  }
+
+  @Test
+  public void testgenerateLocalDateWithCurrentDate_shouldReturnCurrentLocalDate() throws Exception {
+    LocalDate date = new LocalDate();
+    LocalDate localDate = service.generateLocalDate(date.toDate());
+    Assert.assertEquals(localDate, date);
   }
 }


### PR DESCRIPTION
Previously the time part of the transfusedDate was also being
compared with the component's createdOn date. This led to
issues when recording transfusions that was on the same date
that the component was created On.

The check only compares the date portion now by calling a
new DateGeneratorService to convert the dates to a Joda LocalDate
equivalent.