### PR TITLE
BSIS-3390 Fix query find last donation by donor venue and donation date

### DIFF
--- a/src/main/java/org/jembi/bsis/repository/DonationNamedQueryConstants.java
+++ b/src/main/java/org/jembi/bsis/repository/DonationNamedQueryConstants.java
@@ -52,13 +52,13 @@ public class DonationNamedQueryConstants {
       "Donation.findLastDonationsByDonorVenueAndDonationDate";
   public static final String QUERY_FIND_LAST_DONATIONS_BY_DONOR_VENUE_AND_DONATION_DATE =
       "SELECT DISTINCT d "
-      + "FROM Donation d "
-      + "LEFT JOIN FETCH d.bloodTestResults "
-      + "WHERE d.donationDate BETWEEN :startDate AND :endDate "
-      // Only look at the last donation for each donor
-      + "AND d.donationDate = d.donor.dateOfLastDonation "
-      + "AND d.donor.venue = :venue "
-      + "AND d.isDeleted = :deleted ";
+        + "FROM Donation d "
+        + "LEFT JOIN FETCH d.bloodTestResults "
+        + "WHERE d.donationDate BETWEEN :startDate AND :endDate "
+          // Only look at the last donation for each donor
+          + "AND d.donationDate = DATE(d.donor.dateOfLastDonation) "
+          + "AND d.donor.venue = :venue "
+          + "AND d.isDeleted = :deleted ";
   
   public static final String NAME_FIND_DONATION_BY_DONATION_IDENTIFICATION_NUMBER_INCLUDE_DELETED = 
       "Donation.findDonationByDonationIdentificationNumberIncludeDeleted";

--- a/src/test/java/org/jembi/bsis/dialect/BSISTestDialect.java
+++ b/src/test/java/org/jembi/bsis/dialect/BSISTestDialect.java
@@ -11,6 +11,8 @@ public class BSISTestDialect extends HSQLDialect {
     // FIXME: This function is broken.
     registerFunction("date_add_days", new SQLFunctionTemplate(StandardBasicTypes.DATE,
         "?1 + INTERVAL DAY(?2)"));
+    registerFunction("DATE", new SQLFunctionTemplate(StandardBasicTypes.DATE,
+        "?1"));
   }
 
 }


### PR DESCRIPTION
This commit:
- casts d.donor.dateOfLastDonation into a DATE before comparing it to d.donationDate (the type mismatch caused the bug)
- registers a hsqldb function "DATE" to BSISTestDialect (as DATE does not exist in hsqldb by default)