### PR TITLE
BSIS-3492 Fix defects in Do not bleed validation must be done in BackingFormValidator, and not only in DonationCRUDService when an IllegalArgumentException is being thrown.

### DIFF
--- a/src/test/java/org/jembi/bsis/backingform/validator/DonationBackingFormValidatorTest.java
+++ b/src/test/java/org/jembi/bsis/backingform/validator/DonationBackingFormValidatorTest.java
@@ -561,6 +561,41 @@ public class DonationBackingFormValidatorTest {
   }
 
   @Test
+  public void testHistoricalDonationBatchDonationBeforeNextAllowedDate() throws Exception {
+    // set up data
+    UUID locationId = UUID.randomUUID();
+    Location venue = LocationBuilder.aLocation().withId(locationId).thatIsVenue().build();
+    DonationBackingForm form = createBasicBackingForm(venue);
+    form.getDonationBatch().setBackEntry(true);
+    form.getPackType().setPeriodBetweenDonations(20);
+    form.getPackType().setCountAsDonation(Boolean.TRUE);
+    Donation donation = aDonation()
+        .withPackType(form.getPackType())
+        .withDonationDate(new Date())
+        .withBleedStartTime(new Date())
+        .withBleedEndTime(new Date())
+        .withDonationBatch(aDonationBatch().withId(UUID.randomUUID()).build())
+        .withVenue(venue)
+        .withDonationType(aDonationType().withId(UUID.randomUUID()).build())
+        .withDonor(form.getDonor())
+        .build();
+    form.getDonor().setDonations(Arrays.asList(donation));
+
+    // set up mocks
+    when(donorRepository.findDonorByDonorNumber("DN123", false)).thenReturn(form.getDonor());
+    when(donationBatchRepository.findDonationBatchByBatchNumber("DB123")).thenReturn(form.getDonationBatch());
+    when(locationRepository.getLocation(locationId)).thenReturn(venue);
+    mockGeneralConfigAndFormFields();
+
+    // run test
+    Errors errors = new MapBindingResult(new HashMap<String, String>(), "donation");
+    donationBackingFormValidator.validate(form, errors);
+
+    // check asserts
+    Assert.assertEquals("No error exist", 0, errors.getErrorCount());
+  }
+
+  @Test
   public void testDonationBeforeNextAllowedDateWithPackTypeNotCountingAsDonation() throws Exception {
     // set up data
     UUID locationId = UUID.randomUUID();
@@ -630,6 +665,7 @@ public class DonationBackingFormValidatorTest {
     Assert.assertEquals("No errors exist", 0, errors.getErrorCount());
   }
 
+
   @Test
   public void testInvalidDonorDeferred() throws Exception {
     // set up data
@@ -652,6 +688,29 @@ public class DonationBackingFormValidatorTest {
     Assert.assertEquals("Error exist", 1, errors.getErrorCount());
     Assert.assertEquals(errors.getFieldError("donation.donor").getCode(), "errors.invalid.donorDeferred");
     Assert.assertEquals(errors.getFieldError("donation.donor").getDefaultMessage(), "Donor is currently deferred");
+  }
+
+  @Test
+  public void testHistoricalDonationBatchDonorDeferred() throws Exception {
+    // set up data
+    UUID locationId = UUID.randomUUID();
+    Location venue = LocationBuilder.aLocation().withId(locationId).thatIsVenue().build();
+    DonationBackingForm form = createBasicBackingForm(venue);
+    form.getDonationBatch().setBackEntry(true);
+
+    // set up mocks
+    when(donorRepository.findDonorByDonorNumber("DN123", false)).thenReturn(form.getDonor());
+    when(donationBatchRepository.findDonationBatchByBatchNumber("DB123")).thenReturn(form.getDonationBatch());
+    when(locationRepository.getLocation(locationId)).thenReturn(venue);
+    when(donorDeferralStatusCalculator.isDonorCurrentlyDeferred(any(UUID.class))).thenReturn(Boolean.TRUE);
+    mockGeneralConfigAndFormFields();
+
+    // run test
+    Errors errors = new MapBindingResult(new HashMap<String, String>(), "donation");
+    donationBackingFormValidator.validate(form, errors);
+
+    // check asserts
+    Assert.assertEquals("No error exist", 0, errors.getErrorCount());
   }
 
   @Test


### PR DESCRIPTION
BSIS-3492 Fix defects in Do not bleed validation must be done in BackingFormValidator, and not only in DonationCRUDService when an IllegalArgumentException is being thrown.