### PR TITLE
BSIS-3752 Add edit pack type rule to Donation Contraint Checker

### DIFF
--- a/src/main/java/org/jembi/bsis/service/DonationConstraintChecker.java
+++ b/src/main/java/org/jembi/bsis/service/DonationConstraintChecker.java
@@ -170,21 +170,19 @@ public class DonationConstraintChecker {
 
   public boolean canEditToNewPackType(Donation existingDonation, PackType newPackType) {
 
-    if(existingDonation.getTestBatch() != null && 
-        existingDonation.getTestBatch().getStatus() != null &&
-        !existingDonation.getTestBatch().getStatus().equals(TestBatchStatus.OPEN)) {
-
-      if (newPackType.getTestSampleProduced() && 
-          !existingDonation.getPackType().getTestSampleProduced()) {
-        return false;
-      }
-
-      if (existingDonation.getPackType().getTestSampleProduced() && 
-          !newPackType.getTestSampleProduced()) {
+    if(existingDonation.isReleased() || isTestBatchNotOpen(existingDonation)) {
+      //check if pack type change is from one that produces test samples to one that doesn't or vice versa
+      if (existingDonation.getPackType().getTestSampleProduced() != newPackType.getTestSampleProduced()) {
         return false;
       }
     }
     return true;
+  }
+
+  private boolean isTestBatchNotOpen(Donation donation) {
+    return donation.getTestBatch() != null && 
+        donation.getTestBatch().getStatus() != null &&
+        !donation.getTestBatch().getStatus().equals(TestBatchStatus.OPEN);
   }
 
 }

--- a/src/test/java/org/jembi/bsis/service/DonationConstraintCheckerTests.java
+++ b/src/test/java/org/jembi/bsis/service/DonationConstraintCheckerTests.java
@@ -748,4 +748,23 @@ public class DonationConstraintCheckerTests extends UnitTestSuite {
     // Verify
     assertThat(canEditToNewPackType, is(true));
   }
+
+  @Test
+  public void testCanEditToNewPackTypeThatDoesNotProduceTestSamplesFromPackTypeThatDoesWithDonationThatIsReleased_shouldReturnFalse() {
+    // Set up fixture
+    TestBatch testBatch = TestBatchBuilder.aTestBatch().withStatus(TestBatchStatus.OPEN).build();
+    Donation donation = aDonation()
+        .withPackType(aPackType().withTestSampleProduced(true).build())
+        .withDonationBatch(DonationBatchBuilder.aDonationBatch().build())
+        .withTestBatch(testBatch)
+        .thatIsReleased()
+        .build();
+    PackType newPackType = aPackType().withTestSampleProduced(false).build();
+
+    // Exercise SUT
+    boolean canEditToNewPackType = donationConstraintChecker.canEditToNewPackType(donation, newPackType);
+
+    // Verify
+    assertThat(canEditToNewPackType, is(false));
+  }
 }


### PR DESCRIPTION
Previously the pack type of a donation with a test batch that has been
released could be changed from one that produces test samples to
one that does not.

If a sample (DIN) has been released the user should NOT be able to
edit the pack type IF the pack type is changed from one that produces
 a test sample to one that does not produce a test sample.

This commit adds the rule to the backend.