### PR TITLE
BSIS-3775 Fix component preprocess request mapping

### DIFF
--- a/src/main/java/org/jembi/bsis/controller/ComponentController.java
+++ b/src/main/java/org/jembi/bsis/controller/ComponentController.java
@@ -182,7 +182,7 @@ public class ComponentController {
     return new ResponseEntity<Map<String, Object>>(map, HttpStatus.CREATED);
   }
   
-  @RequestMapping(value = "{id}/preprocess ", method = RequestMethod.PUT)
+  @RequestMapping(value = "{id}/preprocess", method = RequestMethod.PUT)
   @PreAuthorize("hasRole('" + PermissionConstants.EDIT_COMPONENT + "')")
   public ResponseEntity<Map<String, Object>> preProcessComponent(
       @PathVariable("id") UUID componentId,


### PR DESCRIPTION
Previously there was a trailing space at the end of the
RequestMapping for the components/preprocess endpoint. This
was not a problem before until updating the relevant spring
dependency. After updated the spring dependency the trailing
space caused the API call, without the trailing space, to not
match the request mapping.

The trailing space is removed in this commit